### PR TITLE
thicc reorg + msg refactor

### DIFF
--- a/benches/sim_bench.rs
+++ b/benches/sim_bench.rs
@@ -7,7 +7,7 @@ use std::hint::black_box;
 use tokio::runtime::Runtime;
 
 async fn run_sim(id: usize, config: Config) {
-    let mut world = World::create(config);
+    let mut world = World::<()>::create(config);
     let agent = TestAgent::new(id, format!("Test{}", id));
     world.spawn(Box::new(agent));
     world.schedule(0.0, id).unwrap();

--- a/examples/realtime.rs
+++ b/examples/realtime.rs
@@ -6,7 +6,7 @@ use aika::TestAgent;
 #[tokio::main]
 async fn main() {
     let config = Config::new(1.0, Some(2000000.0), 100, 100, false, false, false, false);
-    let mut world = World::create(config);
+    let mut world = World::<()>::create(config);
     let agent_test = TestAgent::new(0, "Test".to_string());
     world.spawn(Box::new(agent_test));
     world.schedule(0.0, 0).unwrap();

--- a/examples/realtime.rs
+++ b/examples/realtime.rs
@@ -1,5 +1,3 @@
-use aika::logger::*;
-use aika::universes::*;
 use aika::worlds::*;
 use aika::TestAgent;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-use std::sync::{Arc, Mutex};
-
 use futures::future::BoxFuture;
-use worlds::{Action, Agent, Event, Loggable, Mailbox, Message, State};
+use worlds::{Action, Agent, Event, Mailbox, Message, State};
 
 extern crate tokio;
 
@@ -23,9 +21,9 @@ impl TestAgent {
 impl<T: Send + Sync + Clone> Agent<T> for TestAgent {
     fn step<'a>(
         &'a mut self,
-        state: &'a mut Option<State>,
+        _state: &'a mut Option<State>,
         time: &f64,
-        mailbox: &'a mut Mailbox<T>,
+        _mailbox: &'a mut Mailbox<T>,
     ) -> BoxFuture<'a, Event> {
         let event = Event::new(*time, self.id, Action::Timeout(1.0));
         Box::pin(async { event })
@@ -49,9 +47,9 @@ impl SingleStepAgent {
 impl<T: Send + Sync + Clone> Agent<T> for SingleStepAgent {
     fn step<'a>(
         &'a mut self,
-        state: &'a mut Option<State>,
+        _state: &'a mut Option<State>,
         time: &f64,
-        mailbox: &'a mut Mailbox<T>,
+        _mailbox: &'a mut Mailbox<T>,
     ) -> BoxFuture<'a, Event> {
         let event = Event::new(*time, self.id, Action::Wait);
         Box::pin(async { event })
@@ -75,11 +73,11 @@ impl MessengerAgent {
 impl Agent<Box<&str>> for MessengerAgent {
     fn step<'a>(
         &'a mut self,
-        state: &'a mut Option<State>,
+        _state: &'a mut Option<State>,
         time: &f64,
         mailbox: &'a mut Mailbox<Box<&str>>,
     ) -> BoxFuture<'a, Event> {
-        let mailtome = mailbox
+        let _mailtome = mailbox
             .peek_messages()
             .iter()
             .filter(|m| m.to == self.id)
@@ -96,7 +94,7 @@ impl Agent<Box<&str>> for MessengerAgent {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
+    use std::time::Instant;
 
     use super::worlds::*;
     use super::*;

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -1,35 +1,9 @@
-use std::any::Any;
+use crate::worlds::{Event, State};
 use std::collections::{BTreeMap, BinaryHeap};
 
-use crate::worlds::{Event, State};
+mod snapshot;
 
-/// A snapshot of the world at a given time.
-#[derive(Clone)]
-pub struct Snapshot {
-    pub timestamp: f64,
-    pub shared_state: Option<State>,
-    pub agent_states: BTreeMap<usize, State>,
-}
-
-impl PartialEq for Snapshot {
-    fn eq(&self, other: &Self) -> bool {
-        self.timestamp == other.timestamp
-    }
-}
-
-impl Eq for Snapshot {}
-
-impl PartialOrd for Snapshot {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Snapshot {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.timestamp.partial_cmp(&other.timestamp).unwrap()
-    }
-}
+pub use snapshot::Snapshot;
 
 /// A logger for recording snapshots of the world.
 pub struct Logger {

--- a/src/logger/snapshot.rs
+++ b/src/logger/snapshot.rs
@@ -1,0 +1,30 @@
+use crate::worlds::State;
+use std::collections::BTreeMap;
+
+/// A snapshot of the world at a given time.
+#[derive(Clone)]
+pub struct Snapshot {
+    pub timestamp: f64,
+    pub shared_state: Option<State>,
+    pub agent_states: BTreeMap<usize, State>,
+}
+
+impl PartialEq for Snapshot {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp
+    }
+}
+
+impl Eq for Snapshot {}
+
+impl PartialOrd for Snapshot {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Snapshot {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.timestamp.partial_cmp(&other.timestamp).unwrap()
+    }
+}

--- a/src/universes.rs
+++ b/src/universes.rs
@@ -21,9 +21,9 @@ impl<T: Send + Sync + Clone + 'static> Universe<T> {
     /// Run all worlds in the universe in parallel.
     pub async fn run_parallel(
         &mut self,
-        live: bool,
-        logs: bool,
-        mail: bool,
+        _live: bool,
+        _logs: bool,
+        _mail: bool,
     ) -> Result<Vec<Result<(), SimError>>> {
         let mut handles = vec![];
         let worlds = std::mem::take(&mut self.worlds);

--- a/src/universes.rs
+++ b/src/universes.rs
@@ -5,17 +5,17 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use super::worlds::*;
 
 /// A universe is a collection of worlds that can be run in parallel.
-pub struct Universe {
-    pub worlds: Vec<World>,
+pub struct Universe<T: Send + Sync + Clone> {
+    pub worlds: Vec<World<T>>,
 }
 
-impl Universe {
+impl<T: Send + Sync + Clone + 'static> Universe<T> {
     /// Create a new universe.
     pub fn new() -> Self {
         Universe { worlds: Vec::new() }
     }
     /// Add a world to the universe.
-    pub fn add_world(&mut self, world: World) {
+    pub fn add_world(&mut self, world: World<T>) {
         self.worlds.push(world);
     }
     /// Run all worlds in the universe in parallel.

--- a/src/worlds/agent.rs
+++ b/src/worlds/agent.rs
@@ -1,0 +1,19 @@
+use futures::future::BoxFuture;
+use std::any::Any;
+
+use super::{Event, Mailbox, State};
+
+/// An agent that can be run in a simulation.
+pub trait Agent<T: Send + Sync + Clone>: Send {
+    fn step<'a>(
+        &'a mut self,
+        state: &'a mut Option<State>,
+        time: &f64,
+        mailbox: &'a mut Mailbox<T>,
+    ) -> BoxFuture<'a, Event>;
+    fn as_any(&self) -> &dyn Any;
+}
+
+pub trait Loggable<T: Send + Sync + Clone>: Agent<T> {
+    fn get_state(&self) -> State;
+}

--- a/src/worlds/clock.rs
+++ b/src/worlds/clock.rs
@@ -1,0 +1,125 @@
+use anyhow::Result;
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, VecDeque};
+
+use super::{Event, SimError};
+
+/// The relevant time information for the simulation.
+pub struct Time {
+    pub time: f64,
+    pub step: usize,
+    pub timestep: f64,
+    pub timescale: f64, // 1.0 = real-time, 0.5 = half-time, 2.0 = double-time
+    pub terminal: Option<f64>,
+}
+
+/// A hierarchical timing wheel for scheduling events in a simulation.
+pub struct Clock {
+    wheels: Vec<VecDeque<Vec<Event>>>,
+    slots: usize,
+    height: usize,
+    epoch: usize,
+    pub time: Time,
+}
+
+impl Clock {
+    pub fn new(
+        slots: usize,
+        height: usize,
+        timestep: f64,
+        terminal: Option<f64>,
+    ) -> Result<Self, SimError> {
+        if height < 1 {
+            return Err(SimError::NoClock);
+        }
+        let mut wheels = Vec::new();
+        for _ in 0..height {
+            let mut wheel = VecDeque::new();
+            for _ in 0..slots {
+                wheel.push_back(Vec::new());
+            }
+            wheels.push(wheel);
+        }
+        Ok(Clock {
+            wheels,
+            slots,
+            height,
+            epoch: 0,
+            time: Time {
+                time: 0.0,
+                step: 0,
+                timestep: timestep,
+                timescale: 1.0,
+                terminal: terminal,
+            },
+        })
+    }
+
+    /// Insert an event into the timing wheel.
+    /// checks how many timesteps into the future the event is and selects the appropriate wheel before finding a slot. If too far into the future, the event is returned.
+    pub fn insert(&mut self, event: Event) -> Result<(), Event> {
+        let time = event.time();
+        let delta = time - self.time.time - self.time.timestep;
+
+        for k in 0..self.height {
+            let startidx = ((self.slots).pow(1 + k as u32) - self.slots) / (self.slots - 1);
+            let futurestep = (delta / self.time.timestep) as usize;
+            if futurestep >= startidx {
+                if futurestep
+                    >= ((self.slots).pow(1 + self.height as u32) - self.slots) / (self.slots - 1)
+                {
+                    return Err(event);
+                }
+                let offset = (futurestep - startidx) / self.slots.pow(k as u32);
+                self.wheels[k][offset].push(event);
+                return Ok(());
+            }
+        }
+        Err(event)
+    }
+
+    /// Pop the next timestep's events from the timing wheel and roll the wheel forward.
+    pub fn tick(
+        &mut self,
+        overflow: &mut BTreeSet<Reverse<Event>>,
+    ) -> Result<Vec<Event>, SimError> {
+        let events: Vec<Event> = self.wheels[0].pop_front().unwrap();
+        if !events.is_empty() && events[0].time() < self.time.time {
+            return Err(SimError::TimeTravel);
+        }
+        self.wheels[0].push_back(Vec::new());
+        self.time.time += self.time.timestep;
+        self.time.step += 1;
+        if (self.time.time / self.time.timestep) as u64 % self.slots as u64 == 0 {
+            self.epoch += 1;
+            self.rotate(overflow);
+        }
+        if events.is_empty() {
+            return Err(SimError::NoEvents);
+        }
+        Ok(events)
+    }
+
+    /// Rotate the timing wheel, moving events from the k-th wheel to fill the (k-1)-th wheel.
+    pub fn rotate(&mut self, overflow: &mut BTreeSet<Reverse<Event>>) {
+        let current_step = self.time.step as u64 + 1;
+
+        for k in 1..self.height {
+            let wheel_period = self.slots.pow(k as u32);
+            if current_step % (wheel_period as u64) == 0 {
+                if self.height == k {
+                    for _ in 0..self.slots.pow(self.height as u32 - 1) {
+                        overflow.pop_first().map(|event| self.insert(event.0));
+                    }
+                    return;
+                }
+                if let Some(higher_events) = self.wheels[k].pop_front() {
+                    for event in higher_events {
+                        self.insert(event).unwrap();
+                    }
+                    self.wheels[k].push_back(Vec::new());
+                }
+            }
+        }
+    }
+}

--- a/src/worlds/config.rs
+++ b/src/worlds/config.rs
@@ -1,0 +1,36 @@
+/// Configuration for the world
+#[derive(Clone)]
+pub struct Config {
+    pub timestep: f64,
+    pub terminal: Option<f64>,
+    pub buffer_size: usize,
+    pub mailbox_size: usize,
+    pub live: bool,
+    pub logs: bool,
+    pub mail: bool,
+    pub asyncronous: bool,
+}
+
+impl Config {
+    pub fn new(
+        timestep: f64,
+        terminal: Option<f64>,
+        buffer_size: usize,
+        mailbox_size: usize,
+        live: bool,
+        logs: bool,
+        mail: bool,
+        asyncronous: bool,
+    ) -> Self {
+        Config {
+            timestep,
+            terminal,
+            buffer_size,
+            mailbox_size,
+            live,
+            logs,
+            mail,
+            asyncronous,
+        }
+    }
+}

--- a/src/worlds/error.rs
+++ b/src/worlds/error.rs
@@ -1,0 +1,13 @@
+/// Error enum for provide feedback on simulation errors
+#[derive(Debug, Clone)]
+pub enum SimError {
+    TimeTravel,
+    PastTerminal,
+    ScheduleFailed,
+    PlaybackFroze,
+    NoState,
+    NoEvents,
+    NoClock,
+    InvalidIndex,
+    TokioError(String),
+}

--- a/src/worlds/event.rs
+++ b/src/worlds/event.rs
@@ -1,0 +1,51 @@
+use std::cmp::Ordering;
+
+/// A scheduling action that an agent can take.
+#[derive(Clone, Debug)]
+pub enum Action {
+    Timeout(f64),
+    Schedule(f64),
+    Trigger { time: f64, idx: usize },
+    Wait,
+    Break,
+}
+
+/// An event that can be scheduled in a simulation. This is used to trigger an agent, or schedule another event.
+#[derive(Clone, Debug)]
+pub struct Event {
+    pub time: f64,
+    pub agent: usize,
+    pub yield_: Action,
+}
+
+impl Event {
+    pub fn new(time: f64, agent: usize, yield_: Action) -> Self {
+        Self {
+            time,
+            agent,
+            yield_,
+        }
+    }
+
+    pub fn time(&self) -> f64 {
+        self.time
+    }
+}
+
+impl PartialEq for Event {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+    }
+}
+impl Eq for Event {}
+
+impl PartialOrd for Event {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for Event {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.time.partial_cmp(&other.time).unwrap()
+    }
+}

--- a/src/worlds/mailbox.rs
+++ b/src/worlds/mailbox.rs
@@ -1,0 +1,53 @@
+use super::Message;
+use tokio::sync::{
+    mpsc::{channel, error, Receiver, Sender},
+    watch,
+};
+
+/// A mailbox for agents to send and receive messages. WIP
+pub struct Mailbox<T: Send + Sync + Clone> {
+    tx: Sender<Message<T>>,
+    rx: Receiver<Message<T>>,
+    mailbox: Vec<Message<T>>,
+    pause_rx: watch::Receiver<bool>,
+}
+
+impl<T: Send + Sync + Clone> Mailbox<T> {
+    pub fn new(buffer_size: usize, pause_rx: watch::Receiver<bool>) -> Self {
+        let (tx, rx) = channel(buffer_size);
+        Mailbox {
+            tx,
+            rx,
+            mailbox: Vec::new(),
+            pause_rx,
+        }
+    }
+
+    pub fn is_paused(&self) -> bool {
+        *self.pause_rx.borrow()
+    }
+
+    pub async fn wait_for_resume(&mut self) {
+        while self.is_paused() {
+            self.pause_rx.changed().await.unwrap();
+        }
+    }
+
+    pub async fn send(&self, msg: Message<T>) -> Result<(), error::SendError<Message<T>>> {
+        self.tx.send(msg).await
+    }
+
+    pub async fn receive(&mut self) -> Option<Message<T>> {
+        self.rx.recv().await
+    }
+
+    pub fn peek_messages(&self) -> &[Message<T>] {
+        &self.mailbox
+    }
+
+    pub async fn collect_messages(&mut self) {
+        while let Ok(msg) = self.rx.try_recv() {
+            self.mailbox.push(msg);
+        }
+    }
+}

--- a/src/worlds/message.rs
+++ b/src/worlds/message.rs
@@ -1,0 +1,40 @@
+use std::cmp::Ordering;
+
+/// A message that can be sent between agents.
+pub struct Message<T: Send + Sync + Clone> {
+    pub data: T,
+    pub timestamp: f64,
+    pub from: usize,
+    pub to: usize,
+}
+
+impl<T: Send + Sync + Clone> Message<T> {
+    pub fn new(data: T, timestamp: f64, from: usize, to: usize) -> Self {
+        Message {
+            data,
+            timestamp,
+            from,
+            to,
+        }
+    }
+}
+
+impl<T: Send + Sync + Clone> PartialEq for Message<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp
+    }
+}
+
+impl<T: Send + Sync + Clone> Eq for Message<T> {}
+
+impl<T: Send + Sync + Clone> PartialOrd for Message<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Send + Sync + Clone> Ord for Message<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.timestamp.partial_cmp(&other.timestamp).unwrap()
+    }
+}

--- a/src/worlds/mod.rs
+++ b/src/worlds/mod.rs
@@ -1,0 +1,17 @@
+mod agent;
+mod clock;
+mod config;
+mod error;
+mod event;
+mod mailbox;
+mod message;
+mod world;
+
+pub use agent::{Agent, Loggable};
+pub use clock::{Clock, Time};
+pub use config::Config;
+pub use error::SimError;
+pub use event::{Action, Event};
+pub use mailbox::Mailbox;
+pub use message::Message;
+pub use world::{State, World};

--- a/src/worlds/world.rs
+++ b/src/worlds/world.rs
@@ -1,191 +1,17 @@
-use anyhow::Result;
-use futures::future::BoxFuture;
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+
 use std::any::Any;
-use std::cmp::{Ordering, Reverse};
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::{Arc, Mutex};
-use std::thread::{self, ScopedJoinHandle};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::collections::{BTreeMap, BTreeSet};
+use tokio::sync::{watch, mpsc::{channel, Sender, Receiver}};
 use tokio::io::AsyncBufReadExt;
-use tokio::sync::mpsc::{channel, error, Receiver, Sender};
-use tokio::sync::watch;
+use std::cmp::Reverse;
 
 use crate::logger::Logger;
-
-/// A message that can be sent between agents.
-pub struct Message<T: Send + Sync + Clone> {
-    pub data: T,
-    pub timestamp: f64,
-    pub from: usize,
-    pub to: usize,
-}
-
-impl<T: Send + Sync + Clone> Message<T> {
-    pub fn new(data: T, timestamp: f64, from: usize, to: usize) -> Self {
-        Message {
-            data,
-            timestamp,
-            from,
-            to,
-        }
-    }
-}
-
-impl<T: Send + Sync + Clone> PartialEq for Message<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.timestamp == other.timestamp
-    }
-}
-
-impl<T: Send + Sync + Clone> Eq for Message<T> {}
-
-impl<T: Send + Sync + Clone> PartialOrd for Message<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T: Send + Sync + Clone> Ord for Message<T> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.timestamp.partial_cmp(&other.timestamp).unwrap()
-    }
-}
-
-/// A mailbox for agents to send and receive messages. WIP
-pub struct Mailbox<T: Send + Sync + Clone> {
-    tx: Sender<Message<T>>,
-    rx: Receiver<Message<T>>,
-    mailbox: Vec<Message<T>>,
-    pause_rx: watch::Receiver<bool>,
-}
-
-impl<T: Send + Sync + Clone> Mailbox<T> {
-    pub fn new(buffer_size: usize, pause_rx: watch::Receiver<bool>) -> Self {
-        let (tx, rx) = channel(buffer_size);
-        Mailbox {
-            tx,
-            rx,
-            mailbox: Vec::new(),
-            pause_rx,
-        }
-    }
-
-    pub fn is_paused(&self) -> bool {
-        *self.pause_rx.borrow()
-    }
-
-    pub async fn wait_for_resume(&mut self) {
-        while self.is_paused() {
-            self.pause_rx.changed().await.unwrap();
-        }
-    }
-
-    pub async fn send(&self, msg: Message<T>) -> Result<(), error::SendError<Message<T>>> {
-        self.tx.send(msg).await
-    }
-
-    pub async fn receive(&mut self) -> Option<Message<T>> {
-        self.rx.recv().await
-    }
-
-    pub fn peek_messages(&self) -> &[Message<T>] {
-        &self.mailbox
-    }
-
-    pub async fn collect_messages(&mut self) {
-        while let Ok(msg) = self.rx.try_recv() {
-            self.mailbox.push(msg);
-        }
-    }
-}
-
-/// An agent that can be run in a simulation.
-pub trait Agent<T: Send + Sync + Clone>: Send {
-    fn step<'a>(
-        &'a mut self,
-        state: &'a mut Option<State>,
-        time: &f64,
-        mailbox: &'a mut Mailbox<T>,
-    ) -> BoxFuture<'a, Event>;
-    fn as_any(&self) -> &dyn Any;
-}
-
-pub trait Loggable<T: Send + Sync + Clone>: Agent<T> {
-    fn get_state(&self) -> State;
-}
+use super::{Agent, Action, Clock, Config, Event, Loggable, Mailbox, Message, SimError};
 
 /// Thread-safe loggable generic state type
 pub type State = Arc<Mutex<Vec<Box<dyn Any + Send + Sync>>>>;
-
-/// A scheduling action that an agent can take.
-#[derive(Clone, Debug)]
-pub enum Action {
-    Timeout(f64),
-    Schedule(f64),
-    Trigger { time: f64, idx: usize },
-    Wait,
-    Break,
-}
-
-/// An event that can be scheduled in a simulation. This is used to trigger an agent, or schedule another event.
-#[derive(Clone, Debug)]
-pub struct Event {
-    time: f64,
-    agent: usize,
-    yield_: Action,
-}
-
-impl Event {
-    pub fn new(time: f64, agent: usize, yield_: Action) -> Self {
-        Self {
-            time,
-            agent,
-            yield_,
-        }
-    }
-}
-
-impl PartialEq for Event {
-    fn eq(&self, other: &Self) -> bool {
-        self.time == other.time
-    }
-}
-impl Eq for Event {}
-
-impl PartialOrd for Event {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-impl Ord for Event {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.time.partial_cmp(&other.time).unwrap()
-    }
-}
-
-/// The relevant time information for the simulation.
-struct Time {
-    time: f64,
-    step: usize,
-    timestep: f64,
-    timescale: f64, // 1.0 = real-time, 0.5 = half-time, 2.0 = double-time
-    terminal: Option<f64>,
-}
-
-/// Error enum for provide feedback on simulation errors
-#[derive(Debug, Clone)]
-pub enum SimError {
-    TimeTravel,
-    PastTerminal,
-    ScheduleFailed,
-    PlaybackFroze,
-    NoState,
-    NoEvents,
-    NoClock,
-    InvalidIndex,
-    TokioError(String),
-}
 
 /// Control commands for the real-time simulation
 pub enum ControlCommand {
@@ -200,7 +26,7 @@ pub enum ControlCommand {
 pub struct World<T: Send + Sync + Clone> {
     overflow: BTreeSet<Reverse<Event>>,
     clock: Clock,
-    savedmail: BTreeSet<Message<T>>,
+    _savedmail: BTreeSet<Message<T>>,
     agents: Vec<Box<dyn Agent<T>>>,
     mailbox: Mailbox<T>,
     state: Option<State>,
@@ -215,43 +41,6 @@ pub struct World<T: Send + Sync + Clone> {
 unsafe impl<T: Send + Sync + Clone> Send for World<T> {}
 unsafe impl<T: Send + Sync + Clone> Sync for World<T> {}
 
-/// Configuration for the world
-#[derive(Clone)]
-pub struct Config {
-    pub timestep: f64,
-    pub terminal: Option<f64>,
-    pub buffer_size: usize,
-    pub mailbox_size: usize,
-    pub live: bool,
-    pub logs: bool,
-    pub mail: bool,
-    pub asyncronous: bool,
-}
-
-impl Config {
-    pub fn new(
-        timestep: f64,
-        terminal: Option<f64>,
-        buffer_size: usize,
-        mailbox_size: usize,
-        live: bool,
-        logs: bool,
-        mail: bool,
-        asyncronous: bool,
-    ) -> Self {
-        Config {
-            timestep,
-            terminal,
-            buffer_size,
-            mailbox_size,
-            live,
-            logs,
-            mail,
-            asyncronous,
-        }
-    }
-}
-
 impl<T: Send + Sync + Clone + 'static> World<T> {
     /// Create a new world with the given configuration.
     /// By default, this will include a toggleable CLI for real-time simulation control, a logger for state logging, an asynchronous runtime, and a mailbox for message passing between agents.
@@ -262,7 +51,7 @@ impl<T: Send + Sync + Clone + 'static> World<T> {
         World {
             overflow: BTreeSet::new(),
             clock: Clock::new(256, 1, config.timestep, config.terminal).unwrap(),
-            savedmail: BTreeSet::new(),
+            _savedmail: BTreeSet::new(),
             agents: Vec::new(),
             mailbox,
             runtype: (config.live, config.logs, config.mail, config.asyncronous),
@@ -327,8 +116,8 @@ impl<T: Send + Sync + Clone + 'static> World<T> {
         });
     }
 
-    fn log_mail(&mut self, msg: Message<T>) {
-        self.savedmail.insert(msg);
+    fn _log_mail(&mut self, msg: Message<T>) {
+        self._savedmail.insert(msg);
     }
 
     fn commit(&mut self, event: Event) {
@@ -456,7 +245,7 @@ impl<T: Send + Sync + Clone + 'static> World<T> {
             }
             match self.clock.tick(&mut self.overflow) {
                 Ok(events) => {
-                    // if self.clock.time.step % 10000 == 0 {
+                    // if self.clock.time.step() % 10000 == 0 {
                     //     println!("Processing events {:?}", self.clock.time.time);
                     // }
                     for event in events {
@@ -556,110 +345,3 @@ impl<T: Send + Sync + Clone + 'static> World<T> {
     }
 }
 
-/// A hierarchical timing wheel for scheduling events in a simulation.
-struct Clock {
-    wheels: Vec<VecDeque<Vec<Event>>>,
-    slots: usize,
-    height: usize,
-    epoch: usize,
-    time: Time,
-}
-
-impl Clock {
-    fn new(
-        slots: usize,
-        height: usize,
-        timestep: f64,
-        terminal: Option<f64>,
-    ) -> Result<Self, SimError> {
-        if height < 1 {
-            return Err(SimError::NoClock);
-        }
-        let mut wheels = Vec::new();
-        for _ in 0..height {
-            let mut wheel = VecDeque::new();
-            for _ in 0..slots {
-                wheel.push_back(Vec::new());
-            }
-            wheels.push(wheel);
-        }
-        Ok(Clock {
-            wheels,
-            slots,
-            height,
-            epoch: 0,
-            time: Time {
-                time: 0.0,
-                step: 0,
-                timestep: timestep,
-                timescale: 1.0,
-                terminal: terminal,
-            },
-        })
-    }
-
-    /// Insert an event into the timing wheel.
-    /// checks how many timesteps into the future the event is and selects the appropriate wheel before finding a slot. If too far into the future, the event is returned.
-    fn insert(&mut self, event: Event) -> Result<(), Event> {
-        let time = event.time;
-        let delta = time - self.time.time - self.time.timestep;
-
-        for k in 0..self.height {
-            let startidx = ((self.slots).pow(1 + k as u32) - self.slots) / (self.slots - 1);
-            let futurestep = (delta / self.time.timestep) as usize;
-            if futurestep >= startidx {
-                if futurestep
-                    >= ((self.slots).pow(1 + self.height as u32) - self.slots) / (self.slots - 1)
-                {
-                    return Err(event);
-                }
-                let offset = (futurestep - startidx) / self.slots.pow(k as u32);
-                self.wheels[k][offset].push(event);
-                return Ok(());
-            }
-        }
-        Err(event)
-    }
-
-    /// Pop the next timestep's events from the timing wheel and roll the wheel forward.
-    fn tick(&mut self, overflow: &mut BTreeSet<Reverse<Event>>) -> Result<Vec<Event>, SimError> {
-        let events: Vec<Event> = self.wheels[0].pop_front().unwrap();
-        if !events.is_empty() && events[0].time < self.time.time {
-            return Err(SimError::TimeTravel);
-        }
-        self.wheels[0].push_back(Vec::new());
-        self.time.time += self.time.timestep;
-        self.time.step += 1;
-        if (self.time.time / self.time.timestep) as u64 % self.slots as u64 == 0 {
-            self.epoch += 1;
-            self.rotate(overflow);
-        }
-        if events.is_empty() {
-            return Err(SimError::NoEvents);
-        }
-        Ok(events)
-    }
-
-    /// Rotate the timing wheel, moving events from the k-th wheel to fill the (k-1)-th wheel.
-    fn rotate(&mut self, overflow: &mut BTreeSet<Reverse<Event>>) {
-        let current_step = self.time.step as u64 + 1;
-
-        for k in 1..self.height {
-            let wheel_period = self.slots.pow(k as u32);
-            if current_step % (wheel_period as u64) == 0 {
-                if self.height == k {
-                    for _ in 0..self.slots.pow(self.height as u32 - 1) {
-                        overflow.pop_first().map(|event| self.insert(event.0));
-                    }
-                    return;
-                }
-                if let Some(higher_events) = self.wheels[k].pop_front() {
-                    for event in higher_events {
-                        self.insert(event).unwrap();
-                    }
-                    self.wheels[k].push_back(Vec::new());
-                }
-            }
-        }
-    }
-}

--- a/src/worlds/world.rs
+++ b/src/worlds/world.rs
@@ -1,14 +1,16 @@
-
 use std::any::Any;
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use std::collections::{BTreeMap, BTreeSet};
-use tokio::sync::{watch, mpsc::{channel, Sender, Receiver}};
 use tokio::io::AsyncBufReadExt;
-use std::cmp::Reverse;
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    watch,
+};
 
+use super::{Action, Agent, Clock, Config, Event, Loggable, Mailbox, Message, SimError};
 use crate::logger::Logger;
-use super::{Agent, Action, Clock, Config, Event, Loggable, Mailbox, Message, SimError};
 
 /// Thread-safe loggable generic state type
 pub type State = Arc<Mutex<Vec<Box<dyn Any + Send + Sync>>>>;
@@ -344,4 +346,3 @@ impl<T: Send + Sync + Clone + 'static> World<T> {
         Ok(())
     }
 }
-


### PR DESCRIPTION
first commit changes the `dyn` message data to `T`, which ofc entails the types that ultimately encapsulate the message type.

second commit reorganizes the repo, breaks out chonky modules into more manageable submodules. there were a few changes that came with this as well, such as function & field visibility. also, added some underscore prefixes to silence the 'unused' warnings for a bit.

third commit changes the example directory to match the new changes.

--

> Note: there is a fn in the crate entry point which needs to be `.await`'d but currently is not, so the messenger agent does not actually send the message yet. just writing this down now so we can tackle it another time