### PR TITLE
Polish Examples, rm warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,6 @@ name = "aika"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "realtime"
-path = "examples/realtime.rs"
-
-[[bin]]
-name = "montecarlo"
-path = "examples/montecarlo.rs"
-
 [profile.release]
 debug = true
 

--- a/examples/montecarlo.rs
+++ b/examples/montecarlo.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code, unused_variables)]
 use aika::{
     worlds::{Action, Agent, Config, Event},
     TestAgent,


### PR DESCRIPTION
rm'd some warnings.

you don't need `[[bin]]` in the cargo toml to run them; you can just use `cargo run --example montecarlo`

also added an attribute to the montecarlo "crate" to remove unused variable warnings