### PR TITLE
rm async

### DIFF
--- a/examples/montecarlo.rs
+++ b/examples/montecarlo.rs
@@ -26,15 +26,15 @@ struct MCAgent {
 impl Agent for MCAgent {
     fn step<'a>(
         &mut self,
-        state: &mut Option<&[u8]>,
+        state: &mut Option<Vec<u8>>,
         time: &f64,
-        mailbox: &mut Option<aika::worlds::Mailbox<'a>>,
-    ) -> futures::future::BoxFuture<'a, aika::worlds::Event> {
-        let event = Event::new(*time, self.id, Action::Timeout(1.0));
+        mailbox: &mut Option<aika::worlds::Mailbox>,
+    ) -> Event {
         self.current_value =
             gbm_next_step(self.current_value, self.drift, self.volatility, self.dt);
         self.serialized = self.current_value.to_be_bytes();
-        Box::pin(async { event })
+
+        Event::new(*time, self.id, Action::Timeout(1.0))
     }
 
     fn get_state(&self) -> Option<&[u8]> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,12 +76,10 @@ impl Agent for MessengerAgent {
         time: &f64,
         mailbox: &mut Option<Mailbox>,
     ) -> Event {
-        let _messages = mailbox.as_mut()
-            .unwrap()
-            .receive(self.id);
+        let _messages = mailbox.as_mut().unwrap().receive(self.id);
 
         let return_message = Message::new("Hello".into(), *time + 1.0, self.id, 1);
-        
+
         match mailbox {
             Some(mb) => mb.send(return_message),
             None => (),

--- a/src/universes.rs
+++ b/src/universes.rs
@@ -5,17 +5,17 @@ use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use super::worlds::*;
 
 /// A universe is a collection of worlds that can be run in parallel.
-pub struct Universe<'a, const SLOTS: usize, const HEIGHT: usize> {
-    pub worlds: Vec<World<'a, SLOTS, HEIGHT>>,
+pub struct Universe<const SLOTS: usize, const HEIGHT: usize> {
+    pub worlds: Vec<World<SLOTS, HEIGHT>>,
 }
 
-impl<const SLOTS: usize, const HEIGHT: usize> Universe<'static, SLOTS, HEIGHT> {
+impl<const SLOTS: usize, const HEIGHT: usize> Universe<SLOTS, HEIGHT> {
     /// Create a new universe.
     pub fn new() -> Self {
         Universe { worlds: Vec::new() }
     }
     /// Add a world to the universe.
-    pub fn add_world(&mut self, world: World<'static, SLOTS, HEIGHT>) {
+    pub fn add_world(&mut self, world: World<SLOTS, HEIGHT>) {
         self.worlds.push(world);
     }
     /// Run all worlds in the universe in parallel.
@@ -25,6 +25,14 @@ impl<const SLOTS: usize, const HEIGHT: usize> Universe<'static, SLOTS, HEIGHT> {
         _logs: bool,
         _mail: bool,
     ) -> Result<Vec<Result<(), SimError>>> {
+        // self.worlds.par_iter_mut()
+        //     .map(|world| tokio::spawn(async move { world.run().await }))
+        //     .map(|res| match res {
+                
+        //     })
+        //     .await;
+
+
         let mut handles = vec![];
         let worlds = std::mem::take(&mut self.worlds);
         for mut world in worlds {

--- a/src/universes.rs
+++ b/src/universes.rs
@@ -25,14 +25,6 @@ impl<const SLOTS: usize, const HEIGHT: usize> Universe<SLOTS, HEIGHT> {
         _logs: bool,
         _mail: bool,
     ) -> Result<Vec<Result<(), SimError>>> {
-        // self.worlds.par_iter_mut()
-        //     .map(|world| tokio::spawn(async move { world.run().await }))
-        //     .map(|res| match res {
-                
-        //     })
-        //     .await;
-
-
         let mut handles = vec![];
         let worlds = std::mem::take(&mut self.worlds);
         for mut world in worlds {

--- a/src/worlds/agent.rs
+++ b/src/worlds/agent.rs
@@ -1,14 +1,13 @@
-use futures::future::BoxFuture;
-
 use super::{Event, Mailbox};
 
 /// An agent that can be run in a simulation.
 pub trait Agent: Send {
-    fn step<'a>(
+    fn step(
         &mut self,
-        state: &mut Option<&[u8]>,
+        state: &mut Option<Vec<u8>>,
         time: &f64,
-        mailbox: &mut Option<Mailbox<'a>>,
-    ) -> BoxFuture<'a, Event>;
+        mailbox: &mut Option<Mailbox>,
+    ) -> Event;
+
     fn get_state(&self) -> Option<&[u8]>;
 }

--- a/src/worlds/message.rs
+++ b/src/worlds/message.rs
@@ -2,15 +2,15 @@ use std::cmp::Ordering;
 
 #[derive(Debug, Clone)]
 /// A message that can be sent between agents.
-pub struct Message<'a> {
-    pub data: &'a [u8],
+pub struct Message {
+    pub data: Vec<u8>,
     pub timestamp: f64,
     pub from: usize,
     pub to: usize,
 }
 
-impl<'a> Message<'a> {
-    pub fn new(data: &'a [u8], timestamp: f64, from: usize, to: usize) -> Self {
+impl Message {
+    pub fn new(data: Vec<u8>, timestamp: f64, from: usize, to: usize) -> Self {
         Message {
             data,
             timestamp,
@@ -20,21 +20,21 @@ impl<'a> Message<'a> {
     }
 }
 
-impl<'a> PartialEq for Message<'a> {
+impl PartialEq for Message {
     fn eq(&self, other: &Self) -> bool {
         self.timestamp == other.timestamp
     }
 }
 
-impl<'a> Eq for Message<'a> {}
+impl Eq for Message {}
 
-impl<'a> PartialOrd for Message<'a> {
+impl PartialOrd for Message {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'a> Ord for Message<'a> {
+impl Ord for Message {
     fn cmp(&self, other: &Self) -> Ordering {
         self.timestamp.partial_cmp(&other.timestamp).unwrap()
     }

--- a/src/worlds/world.rs
+++ b/src/worlds/world.rs
@@ -29,10 +29,10 @@ pub struct World<const SLOTS: usize, const HEIGHT: usize> {
     pub logger: Logger,
 }
 
-unsafe impl <const SLOTS: usize, const HEIGHT: usize> Send for World <SLOTS, HEIGHT> {}
-unsafe impl <const SLOTS: usize, const HEIGHT: usize> Sync for World <SLOTS, HEIGHT> {}
+unsafe impl<const SLOTS: usize, const HEIGHT: usize> Send for World<SLOTS, HEIGHT> {}
+unsafe impl<const SLOTS: usize, const HEIGHT: usize> Sync for World<SLOTS, HEIGHT> {}
 
-impl <const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
+impl<const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
     /// Create a new world with the given configuration.
     /// By default, this will include a toggleable CLI for real-time simulation control, a logger for state logging, an asynchronous runtime, and a mailbox for message passing between agents.
     pub fn create(config: Config) -> Self {
@@ -260,8 +260,7 @@ impl <const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
                             break;
                         }
                         let agent = &mut self.agents[event.agent];
-                        let event = agent
-                            .step(&mut self.state, &event.time, &mut self.mailbox);
+                        let event = agent.step(&mut self.state, &event.time, &mut self.mailbox);
                         if self.runtype.1 {
                             let agent_states: BTreeMap<usize, Vec<u8>> = self
                                 .agents

--- a/src/worlds/world.rs
+++ b/src/worlds/world.rs
@@ -17,22 +17,22 @@ pub enum ControlCommand {
 }
 
 /// A world that can contain multiple agents and run a simulation.
-pub struct World<'a, const SLOTS: usize, const HEIGHT: usize> {
+pub struct World<const SLOTS: usize, const HEIGHT: usize> {
     overflow: BTreeSet<Reverse<Event>>,
     clock: Clock<SLOTS, HEIGHT>,
-    _savedmail: BTreeSet<Message<'a>>,
+    _savedmail: BTreeSet<Message>,
     pub agents: Vec<Box<dyn Agent>>,
-    mailbox: Option<Mailbox<'a>>,
-    state: Option<&'a [u8]>,
+    mailbox: Option<Mailbox>,
+    state: Option<Vec<u8>>,
     runtype: (bool, bool, bool),
     pub pause: Option<(watch::Sender<bool>, watch::Receiver<bool>)>,
     pub logger: Logger,
 }
 
-unsafe impl<'a, const SLOTS: usize, const HEIGHT: usize> Send for World<'a, SLOTS, HEIGHT> {}
-unsafe impl<'a, const SLOTS: usize, const HEIGHT: usize> Sync for World<'a, SLOTS, HEIGHT> {}
+unsafe impl <const SLOTS: usize, const HEIGHT: usize> Send for World <SLOTS, HEIGHT> {}
+unsafe impl <const SLOTS: usize, const HEIGHT: usize> Sync for World <SLOTS, HEIGHT> {}
 
-impl<'a, const SLOTS: usize, const HEIGHT: usize> World<'a, SLOTS, HEIGHT> {
+impl <const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
     /// Create a new world with the given configuration.
     /// By default, this will include a toggleable CLI for real-time simulation control, a logger for state logging, an asynchronous runtime, and a mailbox for message passing between agents.
     pub fn create(config: Config) -> Self {
@@ -111,7 +111,7 @@ impl<'a, const SLOTS: usize, const HEIGHT: usize> World<'a, SLOTS, HEIGHT> {
         });
     }
 
-    fn _log_mail(&mut self, msg: Message<'a>) {
+    fn _log_mail(&mut self, msg: Message) {
         self._savedmail.insert(msg);
     }
 
@@ -156,7 +156,7 @@ impl<'a, const SLOTS: usize, const HEIGHT: usize> World<'a, SLOTS, HEIGHT> {
         self.clock.time.step
     }
     /// Clone the current state of the simulation.
-    pub fn state(&self) -> Option<&'a [u8]> {
+    pub fn state(&self) -> Option<Vec<u8>> {
         self.state.clone()
     }
 
@@ -259,13 +259,9 @@ impl<'a, const SLOTS: usize, const HEIGHT: usize> World<'a, SLOTS, HEIGHT> {
                         if event.time > self.clock.time.terminal.unwrap_or(f64::INFINITY) {
                             break;
                         }
-                        if self.runtype.2 {
-                            self.mailbox.as_mut().unwrap().collect_messages().await;
-                        }
                         let agent = &mut self.agents[event.agent];
                         let event = agent
-                            .step(&mut self.state, &event.time, &mut self.mailbox)
-                            .await;
+                            .step(&mut self.state, &event.time, &mut self.mailbox);
                         if self.runtype.1 {
                             let agent_states: BTreeMap<usize, Vec<u8>> = self
                                 .agents
@@ -281,10 +277,9 @@ impl<'a, const SLOTS: usize, const HEIGHT: usize> World<'a, SLOTS, HEIGHT> {
                                 .collect();
                             self.logger.log(
                                 self.now(),
-                                if self.state.is_some() {
-                                    Some(self.state.unwrap().to_vec())
-                                } else {
-                                    None
+                                match &self.state {
+                                    Some(state) => Some(state.clone()),
+                                    None => None,
                                 },
                                 agent_states,
                                 event.clone(),


### PR DESCRIPTION
no pressure to merge this one wrt the discussion about sync vs async, just give the diffs a look and lmk wyt!

i'm thinking if worlds are synchronous in how agents are scheduled and the mailbox is synced every iteration, we can rm the async msg'ing and just let all agents use their mutable reference to the mailbox to "send" msgs when they are executing

this also makes it much cleaner to run worlds in parallel w rayon on the universe level. i think breaking out the cli from the world level to the universe level will be a good idea in the future, but we'll cross that bridge later :3 