### PR TITLE
Parallel Worlds Changes

### DIFF
--- a/benches/sim_bench.rs
+++ b/benches/sim_bench.rs
@@ -2,17 +2,17 @@ use aika::{
     worlds::{Config, World},
     TestAgent,
 };
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
-use tokio::runtime::Runtime;
 
-async fn run_sim(id: usize, config: Config) {
+fn run_sim(id: usize, config: Config) {
     let mut world = World::<256, 1>::create(config);
     let agent = TestAgent::new(id, format!("Test{}", id));
+
     world.spawn(Box::new(agent));
     world.schedule(0.0, id).unwrap();
 
-    world.run().await.unwrap();
+    world.run().unwrap();
 }
 
 fn sim_bench(c: &mut Criterion) {
@@ -21,13 +21,10 @@ fn sim_bench(c: &mut Criterion) {
     let terminal = Some(duration_secs as f64);
 
     // minimal config world, no logs, no mail, no live for base processing speed benchmark
-    let config = Config::new(timestep, terminal, 1000, 1000, false, false, false);
+    let config = Config::new(timestep, terminal, 1000, 1000, false);
 
-    let id: usize = 0;
-
-    c.bench_with_input(BenchmarkId::new("run_sim", id), &id, |b, &i| {
-        b.to_async(Runtime::new().unwrap())
-            .iter(|| run_sim(black_box(i), black_box(config.clone())));
+    c.bench_function("run_sim", |b| {
+        b.iter(|| run_sim(black_box(0), black_box(config.clone())));
     });
 }
 

--- a/examples/montecarlo.rs
+++ b/examples/montecarlo.rs
@@ -90,5 +90,8 @@ async fn main() {
         "Average event processing time: {:.3?} per event",
         elapsed / total_steps as u32
     );
-    println!("logger size: {}", world.logger.unwrap().get_snapshots().len());
+    println!(
+        "logger size: {}",
+        world.logger.unwrap().get_snapshots().len()
+    );
 }

--- a/examples/montecarlo.rs
+++ b/examples/montecarlo.rs
@@ -29,7 +29,7 @@ impl Agent for MCAgent {
         &mut self,
         state: &mut Option<Vec<u8>>,
         time: &f64,
-        mailbox: &mut Option<aika::worlds::Mailbox>,
+        mailbox: &mut aika::worlds::Mailbox,
     ) -> Event {
         self.current_value =
             gbm_next_step(self.current_value, self.drift, self.volatility, self.dt);
@@ -68,7 +68,7 @@ impl MCAgent {
 #[tokio::main]
 async fn main() {
     let ts = 1.0;
-    let config = Config::new(ts, Some(19000000.0), 10, 10, false, true, false);
+    let config = Config::new(ts, Some(19000000.0), 10, 10, true);
     let mut world = aika::worlds::World::<128, 1>::create(config);
     let agent = MCAgent::new(0, "Test".to_string(), 0.1, 0.2, ts, 100.0);
     let agent1 = TestAgent::new(1, "Test1".to_string());
@@ -76,7 +76,7 @@ async fn main() {
     world.spawn(Box::new(agent1));
     //world.schedule(0.0, 0).unwrap();
     let start = std::time::Instant::now();
-    world.run().await.unwrap();
+    world.run().unwrap();
     let elapsed = start.elapsed();
     let total_steps = world.step_counter();
     println!("Benchmark Results:");
@@ -90,5 +90,5 @@ async fn main() {
         "Average event processing time: {:.3?} per event",
         elapsed / total_steps as u32
     );
-    println!("logger size: {}", world.logger.get_snapshots().len());
+    println!("logger size: {}", world.logger.unwrap().get_snapshots().len());
 }

--- a/examples/realtime.rs
+++ b/examples/realtime.rs
@@ -3,14 +3,13 @@ use std::time::Instant;
 use aika::worlds::*;
 use aika::TestAgent;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let duration_secs = 20000000;
     let timestep = 1.0;
     let terminal = Some(duration_secs as f64);
 
     // minimal config world, no logs, no mail, no live for base processing speed benchmark
-    let config = Config::new(timestep, terminal, 10, 10, false, false, false);
+    let config = Config::new(timestep, terminal, 10, 10, false);
     let mut world = World::<128, 1>::create(config);
 
     let agent = TestAgent::new(0, format!("Test{}", 0));
@@ -18,7 +17,7 @@ async fn main() {
     world.schedule(0.0, 0).unwrap();
 
     let start = Instant::now();
-    world.run().await.unwrap();
+    world.run().unwrap();
     let elapsed = start.elapsed();
 
     let total_steps = world.step_counter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,7 @@ impl TestAgent {
 }
 
 impl Agent for TestAgent {
-    fn step(
-        &mut self,
-        _state: &mut Option<Vec<u8>>,
-        time: &f64,
-        _mailbox: &mut Option<Mailbox>,
-    ) -> Event {
+    fn step(&mut self, _state: &mut Option<Vec<u8>>, time: &f64, _mailbox: &mut Mailbox) -> Event {
         Event::new(*time, self.id, Action::Timeout(1.0))
     }
 
@@ -44,12 +39,7 @@ impl SingleStepAgent {
 }
 
 impl Agent for SingleStepAgent {
-    fn step(
-        &mut self,
-        _state: &mut Option<Vec<u8>>,
-        time: &f64,
-        _mailbox: &mut Option<Mailbox>,
-    ) -> Event {
+    fn step(&mut self, _state: &mut Option<Vec<u8>>, time: &f64, _mailbox: &mut Mailbox) -> Event {
         Event::new(*time, self.id, Action::Wait)
     }
 
@@ -70,20 +60,12 @@ impl MessengerAgent {
 }
 
 impl Agent for MessengerAgent {
-    fn step(
-        &mut self,
-        _state: &mut Option<Vec<u8>>,
-        time: &f64,
-        mailbox: &mut Option<Mailbox>,
-    ) -> Event {
-        let _messages = mailbox.as_mut().unwrap().receive(self.id);
+    fn step(&mut self, _state: &mut Option<Vec<u8>>, time: &f64, mailbox: &mut Mailbox) -> Event {
+        let _messages = mailbox.receive(self.id);
 
         let return_message = Message::new("Hello".into(), *time + 1.0, self.id, 1);
 
-        match mailbox {
-            Some(mb) => mb.send(return_message),
-            None => (),
-        }
+        mailbox.send(return_message);
 
         Event::new(*time, self.id, Action::Wait)
     }
@@ -102,12 +84,12 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_run() {
-        let config = Config::new(1.0, Some(2000000.0), 100, 100, false, false, false);
+        let config = Config::new(1.0, Some(2000000.0), 100, 100, false);
         let mut world = World::<256, 1>::create(config);
         let agent_test = TestAgent::new(0, "Test".to_string());
         world.spawn(Box::new(agent_test));
         world.schedule(0.0, 0).unwrap();
-        assert!(world.run().await.unwrap() == ());
+        assert!(world.run().unwrap() == ());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -117,7 +99,7 @@ mod tests {
         let terminal = Some(duration_secs as f64);
 
         // minimal config world, no logs, no mail, no live for base processing speed benchmark
-        let config = Config::new(timestep, terminal, 10, 10, false, false, false);
+        let config = Config::new(timestep, terminal, 10, 10, false);
         let mut world = World::<128, 1>::create(config);
 
         let agent = TestAgent::new(0, format!("Test{}", 0));
@@ -125,7 +107,7 @@ mod tests {
         world.schedule(0.0, 0).unwrap();
 
         let start = Instant::now();
-        world.run().await.unwrap();
+        world.run().unwrap();
         let elapsed = start.elapsed();
 
         let total_steps = world.step_counter();
@@ -145,7 +127,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_periphery() {
-        let config = Config::new(1.0, Some(1000.0), 100, 100, false, true, false);
+        let config = Config::new(1.0, Some(1000.0), 100, 100, true);
         let mut world = World::<256, 1>::create(config);
         let agent_test = SingleStepAgent::new(0, "Test".to_string());
         world.spawn(Box::new(agent_test));
@@ -155,10 +137,12 @@ mod tests {
         assert!(world.now() == 0.0);
         assert!(world.state().is_none());
 
-        world.run().await.unwrap();
+        world.run().unwrap();
 
         assert!(world
             .logger
+            .as_ref()
+            .unwrap()
             .get_snapshots()
             .pop()
             .unwrap()
@@ -167,6 +151,8 @@ mod tests {
         assert!(
             world
                 .logger
+                .as_ref()
+                .unwrap()
                 .get_snapshots()
                 .pop()
                 .unwrap()
@@ -174,7 +160,17 @@ mod tests {
                 .len()
                 == 0
         );
-        assert!(world.logger.get_snapshots().pop().unwrap().timestamp == 1.0);
+        assert!(
+            world
+                .logger
+                .as_ref()
+                .unwrap()
+                .get_snapshots()
+                .pop()
+                .unwrap()
+                .timestamp
+                == 1.0
+        );
 
         assert!(world.now() == 1000.0);
         assert!(world.step_counter() == 1000);

--- a/src/worlds/agent.rs
+++ b/src/worlds/agent.rs
@@ -2,12 +2,7 @@ use super::{Event, Mailbox};
 
 /// An agent that can be run in a simulation.
 pub trait Agent: Send {
-    fn step(
-        &mut self,
-        state: &mut Option<Vec<u8>>,
-        time: &f64,
-        mailbox: &mut Option<Mailbox>,
-    ) -> Event;
+    fn step(&mut self, state: &mut Option<Vec<u8>>, time: &f64, mailbox: &mut Mailbox) -> Event;
 
     fn get_state(&self) -> Option<&[u8]>;
 }

--- a/src/worlds/config.rs
+++ b/src/worlds/config.rs
@@ -5,9 +5,7 @@ pub struct Config {
     pub terminal: Option<f64>,
     pub buffer_size: usize,
     pub mailbox_size: usize,
-    pub live: bool,
     pub logs: bool,
-    pub mail: bool,
 }
 
 impl Config {
@@ -16,18 +14,14 @@ impl Config {
         terminal: Option<f64>,
         buffer_size: usize,
         mailbox_size: usize,
-        live: bool,
         logs: bool,
-        mail: bool,
     ) -> Self {
         Config {
             timestep,
             terminal,
             buffer_size,
             mailbox_size,
-            live,
             logs,
-            mail,
         }
     }
 }

--- a/src/worlds/world.rs
+++ b/src/worlds/world.rs
@@ -40,11 +40,7 @@ impl<const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
             agents: Vec::new(),
             mailbox: Mailbox::new(config.mailbox_size),
             state: None,
-            logger: if config.logs {
-                Some(Logger::new())
-            } else {
-                None
-            },
+            logger: config.logs.then_some(Logger::new()),
         }
     }
 

--- a/src/worlds/world.rs
+++ b/src/worlds/world.rs
@@ -71,6 +71,7 @@ impl<const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
     }
 
     /// Get the current time of the simulation.
+    #[inline(always)]
     pub fn now(&self) -> f64 {
         self.clock.time.time
     }
@@ -143,7 +144,7 @@ impl<const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
                             &mut self.mailbox,
                         );
 
-                        self.handle_log(&event);
+                        self.handle_log(event);
 
                         match event.yield_ {
                             Action::Timeout(time) => {

--- a/src/worlds/world.rs
+++ b/src/worlds/world.rs
@@ -178,6 +178,8 @@ impl<const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
         Ok(())
     }
 
+    /// Handles logging of events, provided the logger is active.
+    #[inline(always)]
     fn handle_log(&mut self, event: &Event) {
         if let Some(logger) = &mut self.logger {
             let agent_states: BTreeMap<usize, Vec<u8>> = self

--- a/src/worlds/world.rs
+++ b/src/worlds/world.rs
@@ -1,20 +1,19 @@
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet};
-use std::time::Duration;
-use tokio::io::AsyncBufReadExt;
-use tokio::sync::{mpsc::Sender, watch};
 
 use super::{Action, Agent, Clock, Config, Event, Mailbox, Message, SimError};
 use crate::logger::Logger;
 
 /// Control commands for the real-time simulation
-pub enum ControlCommand {
-    Pause,
-    Resume,
-    SetTimeScale(f64),
-    Quit,
-    Schedule(f64, usize),
-}
+///
+/// TODO: breakout to universe level & let worlds read them on tick
+// pub enum ControlCommand {
+//     Pause,
+//     Resume,
+//     SetTimeScale(f64),
+//     Quit,
+//     Schedule(f64, usize),
+// }
 
 /// A world that can contain multiple agents and run a simulation.
 pub struct World<const SLOTS: usize, const HEIGHT: usize> {
@@ -22,11 +21,9 @@ pub struct World<const SLOTS: usize, const HEIGHT: usize> {
     clock: Clock<SLOTS, HEIGHT>,
     _savedmail: BTreeSet<Message>,
     pub agents: Vec<Box<dyn Agent>>,
-    mailbox: Option<Mailbox>,
+    mailbox: Mailbox,
     state: Option<Vec<u8>>,
-    runtype: (bool, bool, bool),
-    pub pause: Option<(watch::Sender<bool>, watch::Receiver<bool>)>,
-    pub logger: Logger,
+    pub logger: Option<Logger>,
 }
 
 unsafe impl<const SLOTS: usize, const HEIGHT: usize> Send for World<SLOTS, HEIGHT> {}
@@ -36,79 +33,25 @@ impl<const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
     /// Create a new world with the given configuration.
     /// By default, this will include a toggleable CLI for real-time simulation control, a logger for state logging, an asynchronous runtime, and a mailbox for message passing between agents.
     pub fn create(config: Config) -> Self {
-        let pause = if config.live {
-            Some(watch::channel(false))
-        } else {
-            None
-        };
-        let mailbox = if config.mail {
-            Some(Mailbox::new(config.mailbox_size))
-        } else {
-            None
-        };
         World {
             overflow: BTreeSet::new(),
             clock: Clock::<SLOTS, HEIGHT>::new(config.timestep, config.terminal).unwrap(),
             _savedmail: BTreeSet::new(),
             agents: Vec::new(),
-            mailbox,
-            runtype: (config.live, config.logs, config.mail),
+            mailbox: Mailbox::new(config.mailbox_size),
             state: None,
-            pause,
-            logger: Logger::new(),
+            logger: if config.logs {
+                Some(Logger::new())
+            } else {
+                None
+            },
         }
     }
+
     /// Spawn a new agent into the world.
     pub fn spawn(&mut self, agent: Box<dyn Agent>) -> usize {
         self.agents.push(agent);
         self.agents.len() - 1
-    }
-
-    fn spawn_cli(&self, cmd_tx: Sender<ControlCommand>) {
-        tokio::spawn(async move {
-            let mut reader = tokio::io::BufReader::new(tokio::io::stdin());
-            loop {
-                let mut line = String::new();
-                if reader.read_line(&mut line).await.is_ok() {
-                    let cmd = match line.trim() {
-                        "pause" => ControlCommand::Pause,
-                        "resume" => ControlCommand::Resume,
-                        "quit" => ControlCommand::Quit,
-                        cmd if cmd.starts_with("speed ") => {
-                            if let Some(scale) = cmd
-                                .split_whitespace()
-                                .nth(1)
-                                .and_then(|s| s.parse::<f64>().ok())
-                            {
-                                ControlCommand::SetTimeScale(scale)
-                            } else {
-                                continue;
-                            }
-                        }
-                        cmd if cmd.starts_with("schedule ") => {
-                            let parts: Vec<_> = cmd.split_whitespace().collect();
-                            if parts.len() >= 3 {
-                                if let (Some(time), Some(idx)) =
-                                    (parts[1].parse::<f64>().ok(), parts[2].parse::<usize>().ok())
-                                {
-                                    ControlCommand::Schedule(time, idx)
-                                } else {
-                                    continue;
-                                }
-                            } else {
-                                continue;
-                            }
-                        }
-                        _ => continue,
-                    };
-                    if cmd_tx.send(cmd).await.is_err() {
-                        break;
-                    }
-                } else {
-                    break;
-                }
-            }
-        });
     }
 
     fn _log_mail(&mut self, msg: Message) {
@@ -121,40 +64,22 @@ impl<const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
             self.overflow.insert(Reverse(event_maybe.err().unwrap()));
         }
     }
-    /// Pause the real-time simulation.
-    pub fn pause(&mut self) -> Result<(), SimError> {
-        if self.pause.is_none() {
-            return Err(SimError::NotRealtime);
-        }
-        let pause = self.pause.as_mut().unwrap().0.send(true);
-        if pause.is_err() {
-            return Err(SimError::PlaybackFroze);
-        }
-        Ok(())
-    }
-    /// Resume the real-time simulation.
-    pub fn resume(&mut self) -> Result<(), SimError> {
-        if self.pause.is_none() {
-            return Err(SimError::NotRealtime);
-        }
-        let resume = self.pause.as_mut().unwrap().0.send(false);
-        if resume.is_err() {
-            return Err(SimError::PlaybackFroze);
-        }
-        Ok(())
-    }
+
     /// speed up/slow down the simulation playback.
     pub fn rescale_time(&mut self, timescale: f64) {
         self.clock.time.timescale = timescale;
     }
+
     /// Get the current time of the simulation.
     pub fn now(&self) -> f64 {
         self.clock.time.time
     }
+
     /// Get the current step of the simulation.
     pub fn step_counter(&self) -> usize {
         self.clock.time.step
     }
+
     /// Clone the current state of the simulation.
     pub fn state(&self) -> Option<Vec<u8>> {
         self.state.clone()
@@ -186,152 +111,92 @@ impl<const SLOTS: usize, const HEIGHT: usize> World<SLOTS, HEIGHT> {
 
     /// Schedule an event for an agent at a given time.
     pub fn schedule(&mut self, time: f64, agent: usize) -> Result<(), SimError> {
-        if time < self.clock.time.time {
+        if time < self.now() {
             return Err(SimError::TimeTravel);
         } else if time > self.clock.time.terminal.unwrap_or(f64::INFINITY) {
             return Err(SimError::PastTerminal);
         }
+
         self.commit(Event::new(time, agent, Action::Wait));
         Ok(())
     }
 
     /// Run the simulation.
-    pub async fn run(&mut self) -> Result<(), SimError> {
-        let mut g = if self.runtype.0 {
-            Some(tokio::sync::mpsc::channel(100))
-        } else {
-            None
-        };
-        if self.runtype.0 {
-            self.spawn_cli(g.as_mut().unwrap().0.clone());
-        }
+    pub fn run(&mut self) -> Result<(), SimError> {
         loop {
-            if self.clock.time.time + self.clock.time.timestep
+            if self.now() + self.clock.time.timestep
                 > self.clock.time.terminal.unwrap_or(f64::INFINITY)
             {
                 break;
             }
-            if self.runtype.0 {
-                while let Ok(cmd) = g.as_mut().unwrap().1.try_recv() {
-                    match cmd {
-                        ControlCommand::Pause => self.pause()?,
-                        ControlCommand::Resume => self.resume()?,
-                        ControlCommand::SetTimeScale(scale) => self.rescale_time(scale),
-                        ControlCommand::Quit => break,
-                        ControlCommand::Schedule(time, idx) => {
-                            self.commit(Event::new(time, idx, Action::Wait));
-                        }
-                    }
-                }
-                if *self.pause.as_mut().unwrap().1.borrow() {
-                    tokio::select! {
-                        _ = self.pause.as_mut().unwrap().1.changed() => {},
-                        cmd = g.as_mut().unwrap().1.recv() => {
-                            if let Some(cmd) = cmd {
-                                match cmd {
-                                    ControlCommand::Pause => self.pause()?,
-                                    ControlCommand::Resume => self.resume()?,
-                                    ControlCommand::SetTimeScale(scale) => self.rescale_time(scale),
-                                    ControlCommand::Quit => break,
-                                    ControlCommand::Schedule(time, idx) => {
-                                        self.commit(Event::new(time, idx, Action::Wait));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    continue;
-                }
-            }
+
             match self.clock.tick(&mut self.overflow) {
                 Ok(events) => {
-                    // if self.clock.time.step % 10000 == 0 {
-                    //     println!("Processing events {:?}", self.clock.time.time);
-                    // }
                     for event in events {
-                        if self.runtype.0 {
-                            tokio::time::sleep(Duration::from_millis(
-                                (self.clock.time.timestep * 1000.0 / self.clock.time.timescale)
-                                    as u64,
-                            ))
-                            .await;
-                        }
                         if event.time > self.clock.time.terminal.unwrap_or(f64::INFINITY) {
                             break;
                         }
-                        let agent = &mut self.agents[event.agent];
-                        let event = agent.step(&mut self.state, &event.time, &mut self.mailbox);
-                        if self.runtype.1 {
-                            let agent_states: BTreeMap<usize, Vec<u8>> = self
-                                .agents
-                                .iter()
-                                .enumerate()
-                                .filter_map(|(i, agt)| {
-                                    if agt.get_state().is_some() {
-                                        Some((i, agt.get_state().unwrap().to_vec()))
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect();
-                            self.logger.log(
-                                self.now(),
-                                match &self.state {
-                                    Some(state) => Some(state.clone()),
-                                    None => None,
-                                },
-                                agent_states,
-                                event.clone(),
-                            );
-                        }
+
+                        let event = &mut self.agents[event.agent].step(
+                            &mut self.state,
+                            &event.time,
+                            &mut self.mailbox,
+                        );
+
+                        self.handle_log(&event);
+
                         match event.yield_ {
                             Action::Timeout(time) => {
-                                if self.clock.time.time + time
+                                if self.now() + time
                                     > self.clock.time.terminal.unwrap_or(f64::INFINITY)
                                 {
                                     continue;
                                 }
-                                let new = Event::new(
-                                    self.clock.time.time + time,
+
+                                self.commit(Event::new(
+                                    self.now() + time,
                                     event.agent,
                                     Action::Wait,
-                                );
-                                self.commit(new);
+                                ));
                             }
                             Action::Schedule(time) => {
-                                let new = Event::new(time, event.agent, Action::Wait);
-                                self.commit(new);
+                                self.commit(Event::new(time, event.agent, Action::Wait));
                             }
                             Action::Trigger { time, idx } => {
-                                let new = Event::new(time, idx, Action::Wait);
-                                self.commit(new);
+                                self.commit(Event::new(time, idx, Action::Wait));
                             }
                             Action::Wait => {}
                             Action::Break => {
                                 break;
                             }
                         }
-                        if self.runtype.0 {
-                            while let Ok(cmd) = g.as_mut().unwrap().1.try_recv() {
-                                match cmd {
-                                    ControlCommand::Pause => self.pause()?,
-                                    ControlCommand::Resume => self.resume()?,
-                                    ControlCommand::SetTimeScale(scale) => self.rescale_time(scale),
-                                    ControlCommand::Quit => break,
-                                    ControlCommand::Schedule(time, idx) => {
-                                        self.commit(Event::new(time, idx, Action::Wait));
-                                    }
-                                }
-                            }
-                        }
                     }
-                }
-                Err(SimError::NoEvents) => {
-                    continue;
                 }
                 Err(_) => {}
             }
         }
         Ok(())
+    }
+
+    fn handle_log(&mut self, event: &Event) {
+        if let Some(logger) = &mut self.logger {
+            let agent_states: BTreeMap<usize, Vec<u8>> = self
+                .agents
+                .iter()
+                .filter_map(|agent| agent.get_state())
+                .map(|state| state.to_vec())
+                .enumerate()
+                .collect();
+
+            logger.log(
+                self.clock.time.time,
+                match &self.state {
+                    Some(state) => Some(state.clone()),
+                    None => None,
+                },
+                agent_states,
+                event.clone(),
+            );
+        }
     }
 }


### PR DESCRIPTION
ok made some changes that makes world running in parallel a lil easier:

```rust
// -- snip
    pub fn run_parallel(&mut self) -> Vec<Result<(), SimError>> {
        self.worlds
            .par_iter_mut()
            .map(|world| world.run())
            .collect()
    }
// -- snip
```

notable changes include:

- `Option<MailBox>` -> `Mailbox` (it can just be empty and occupy no memory)
- rm `live` config option
- rm cli from world
- rm `Command` (commented out, we'll need it later)
- `log: bool, logger: Logger` -> `Option<Logger>`
- breakout `handle_log` fn to flatten the loop a bit
- make benches/tests synchronous

on `live`, `spawn_cli`, and `Command: i think the idea of injecting commands into a world is good, so i think later once we're ready to do live mode stuff, there should be a universe-level cli where we can issue cmd's to worlds. this will add complexity and hit performance, but we can handle this issue when the time comes.

otherwise, 