### PR TITLE
Update to mesocarp v0.12.1 comms

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -93,26 +93,6 @@ jobs:
       - name: Run TOML fmt
         run: taplo fmt --check
 
-  check-wasm:
-    name: check-wasm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: rust/check-wasm
-
-      - name: Install WASM target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: Run cargo check for WASM
-        run: cargo check --workspace --target wasm32-unknown-unknown
-
   # semver:
   #   name: semver
   #   runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,10 @@ opt-level = 3
 bytemuck = "1.23.0"
 thiserror = "2.0.12"
 downcast-rs = "2.0.1"
+crossbeam-queue = "0.3.2"
 chrono = { version = "0.4.41", features = ["serde"] }
 
-mesocarp = "0.10.1"
+mesocarp = "0.12.0"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ downcast-rs = "2.0.1"
 crossbeam-queue = "0.3.2"
 chrono = { version = "0.4.41", features = ["serde"] }
 
-mesocarp = "0.12.0"
+mesocarp = "0.12.1"
 
 
 [dev-dependencies]

--- a/benches/hlocal_overhead.rs
+++ b/benches/hlocal_overhead.rs
@@ -53,7 +53,7 @@ fn bench_events_per_second(c: &mut Criterion) {
                     || {
                         let mut stager = stager!((), BLOCK_BW = 512).unwrap();
                         stager
-                            .config(Config::new(6, 40, 1024, sim_time, 1000000))
+                            .config(Config::new(6, 128, 40, 1024, sim_time, 1000000))
                             .unwrap();
 
                         for _ in 0..6 {

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -2,7 +2,7 @@
 //! Provides `Agent` trait for single-threaded clusters and `ThreadedAgent` for multi-threaded planets,
 //! along with their respective context structures that manage state and inter-agent communication.
 use bytemuck::{Pod, Zeroable};
-use mesocarp::logging::journal::Journal;
+use mesocarp::logging::Journal;
 
 use crate::{
     env::Environment,

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -93,7 +93,7 @@ impl<MessageType: Pod + Zeroable + Clone> Context<MessageType> {
 }
 
 /// An `Actor` is an independent logical process that belongs to a `Planet` and can schedule events.
-pub trait Actor<MessageType: Clone + Pod + Zeroable>: std::fmt::Debug {
+pub trait Actor<MessageType: Clone + Pod + Zeroable> {
     fn step(
         &mut self,
         env: &mut Context<MessageType>,

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,5 @@
 use downcast_rs::{impl_downcast, Downcast};
-use mesocarp::logging::journal::Journal;
+use mesocarp::logging::Journal;
 
 pub trait Environment: Downcast + std::fmt::Debug {
     fn rollback(&mut self, time: u64);

--- a/src/mt/consensus.rs
+++ b/src/mt/consensus.rs
@@ -11,13 +11,9 @@ use std::{fmt::Display, fs::File, io::Write, sync::Arc, time::Instant};
 
 use bytemuck::{Pod, Zeroable};
 
+use crossbeam_queue::ArrayQueue;
 use mesocarp::{
-    comms::{
-        spmc::{Broadcast, Subscriber},
-        spsc::BufferWheel,
-    },
-    logging::journal::Journal,
-    MesoError,
+    comms::mt::{Broadcaster, Subscriber}, logging::Journal, MesoError
 };
 
 use crate::AikaError;
@@ -205,21 +201,21 @@ impl<const BANDWIDTH: usize> Default for Block<BANDWIDTH> {
 /// a fully decentralized set up, just specify the mode with `ComputeLayout`.
 pub struct BlockProcessor<const BANDWIDTH: usize> {
     mode: ComputeLayout,
-    block_receiver_centralized: Option<Vec<Arc<BufferWheel<BANDWIDTH, Block<BANDWIDTH>>>>>,
-    safe_point_centralized: Option<Arc<Broadcast<BANDWIDTH, u64>>>,
+    block_receiver_centralized: Option<Vec<Arc<ArrayQueue<Block<BANDWIDTH>>>>>,
+    safe_point_centralized: Option<Arc<Broadcaster<u64>>>,
     centralized_registrations: usize,
-    block_receiver_decentralized: Option<Vec<Subscriber<BANDWIDTH, Block<BANDWIDTH>>>>,
+    block_receiver_decentralized: Option<Vec<Subscriber<Block<BANDWIDTH>>>>,
 }
 
 impl<const BANDWIDTH: usize> BlockProcessor<BANDWIDTH> {
     /// Spawn a new `BlockProcessor<const BANDWIDTH: usize>`.
-    pub fn new(mode: ComputeLayout) -> Result<Self, MesoError> {
+    pub fn new(mode: ComputeLayout, feeders: usize) -> Result<Self, MesoError> {
         let block_receiver_centralized = match mode {
             ComputeLayout::HubSpoke => Some(Vec::new()),
             ComputeLayout::Decentralized => None,
         };
         let safe_point_centralized = match mode {
-            ComputeLayout::HubSpoke => Some(Arc::new(Broadcast::new()?)),
+            ComputeLayout::HubSpoke => Some(Arc::new(Broadcaster::new(feeders, BANDWIDTH))),
             ComputeLayout::Decentralized => None,
         };
         let block_receiver_decentralized = match mode {
@@ -240,7 +236,7 @@ impl<const BANDWIDTH: usize> BlockProcessor<BANDWIDTH> {
         if self.mode != ComputeLayout::HubSpoke {
             return Err(AikaError::ComputeLayoutExpectationMismatch(self.mode));
         }
-        let wheel = Arc::new(BufferWheel::new());
+        let wheel = Arc::new(ArrayQueue::new(BANDWIDTH));
         let cloned = Arc::clone(&wheel);
         self.block_receiver_centralized
             .as_mut()
@@ -250,7 +246,7 @@ impl<const BANDWIDTH: usize> BlockProcessor<BANDWIDTH> {
             .safe_point_centralized
             .as_mut()
             .unwrap()
-            .register_subscriber();
+            .subscribe(self.centralized_registrations);
         self.centralized_registrations += 1;
         Ok(BlockSpoke {
             submitter: cloned,
@@ -262,7 +258,7 @@ impl<const BANDWIDTH: usize> BlockProcessor<BANDWIDTH> {
     /// Register a producer in the decentralized layout. Will be rejected if the layout mode is not set correctly.
     pub fn register_decentralized_producer(
         &mut self,
-        sub: Subscriber<BANDWIDTH, Block<BANDWIDTH>>,
+        sub: Subscriber<Block<BANDWIDTH>>,
     ) -> Result<(), AikaError> {
         if self.mode != ComputeLayout::Decentralized {
             return Err(AikaError::ComputeLayoutExpectationMismatch(self.mode));
@@ -277,7 +273,7 @@ impl<const BANDWIDTH: usize> BlockProcessor<BANDWIDTH> {
     /// Wrapper for producer registration on any compute layout.
     pub fn register_producer(
         &mut self,
-        sub: Option<Subscriber<BANDWIDTH, Block<BANDWIDTH>>>,
+        sub: Option<Subscriber<Block<BANDWIDTH>>>,
     ) -> Result<Option<BlockSpoke<BANDWIDTH>>, AikaError> {
         match self.mode {
             ComputeLayout::HubSpoke => Ok(Some(self.register_centralized_producer()?)),
@@ -298,14 +294,8 @@ impl<const BANDWIDTH: usize> BlockProcessor<BANDWIDTH> {
                 for i in comms {
                     let mut planet_blocks = Vec::new();
                     for _ in 0..BANDWIDTH {
-                        match i.read() {
-                            Ok(block) => planet_blocks.push(block),
-                            Err(err) => {
-                                if let MesoError::NoPendingUpdates = err {
-                                    break;
-                                }
-                                return Err(err);
-                            }
+                        if let Some(block) = i.pop() {
+                            planet_blocks.push(block)
                         }
                     }
                     if !planet_blocks.is_empty() {
@@ -327,7 +317,7 @@ impl<const BANDWIDTH: usize> BlockProcessor<BANDWIDTH> {
         if self.mode != ComputeLayout::HubSpoke {
             return Err(AikaError::ComputeLayoutExpectationMismatch(self.mode));
         }
-        self.safe_point_centralized.as_mut().unwrap().broadcast(gvt);
+        self.safe_point_centralized.as_mut().unwrap().push(gvt);
         Ok(())
     }
 }
@@ -351,10 +341,10 @@ pub struct Consensus<const BANDWIDTH: usize> {
 impl<const BANDWIDTH: usize> Consensus<BANDWIDTH> {
     /// Spawn a new `Consensus` with a given compute layout.
     /// `batch_size: usize` input defines the size of the arena allocation used in the `Journal`.
-    pub fn new(mode: ComputeLayout, batch_size: usize) -> Result<Self, MesoError> {
+    pub fn new(mode: ComputeLayout, batch_size: usize, feeders: usize) -> Result<Self, MesoError> {
         let blocksize = BANDWIDTH * 16 + 48;
         Ok(Self {
-            processor: BlockProcessor::new(mode)?,
+            processor: BlockProcessor::new(mode, feeders)?,
             queue: Vec::new(),
             next: Vec::new(),
             blocks: Journal::init(batch_size * blocksize),
@@ -367,7 +357,7 @@ impl<const BANDWIDTH: usize> Consensus<BANDWIDTH> {
     #[inline(always)]
     pub fn register_producer(
         &mut self,
-        sub: Option<Subscriber<BANDWIDTH, Block<BANDWIDTH>>>,
+        sub: Option<Subscriber<Block<BANDWIDTH>>>,
     ) -> Result<Option<BlockSpoke<BANDWIDTH>>, AikaError> {
         let out = self.processor.register_producer(sub)?;
         self.queue.push([None; BANDWIDTH]);
@@ -574,9 +564,9 @@ impl<const BANDWIDTH: usize> Consensus<BANDWIDTH> {
 /// Wrapper struct for the block management utils necessary to manage and communicate block updates in GVT Master layout.
 pub struct BlockSpoke<const BANDWIDTH: usize> {
     /// Block submitter back to the GVT Master thread.
-    pub submitter: Arc<BufferWheel<BANDWIDTH, Block<BANDWIDTH>>>,
+    pub submitter: Arc<ArrayQueue<Block<BANDWIDTH>>>,
     /// Subscriber for GVT updates sent out by the GVT Master thread.
-    pub subscriber: Subscriber<BANDWIDTH, u64>,
+    pub subscriber: Subscriber<u64>,
     /// Current block.
     pub block: Block<BANDWIDTH>,
 }
@@ -599,7 +589,7 @@ mod unit_tests {
 
     fn setup_consensus(num_producers: usize) -> (Consensus<BANDWIDTH>, Vec<BlockSpoke<BANDWIDTH>>) {
         let mut consensus =
-            Consensus::<BANDWIDTH>::new(ComputeLayout::HubSpoke, num_producers).unwrap();
+            Consensus::<BANDWIDTH>::new(ComputeLayout::HubSpoke, num_producers, num_producers).unwrap();
         let mut spokes = Vec::new();
 
         for _ in 0..num_producers {
@@ -881,7 +871,7 @@ mod unit_tests {
 
         // Setup consensus that can be shared via Mutex
         let mut consensus =
-            Consensus::<BANDWIDTH>::new(ComputeLayout::HubSpoke, PARALLEL_PRODUCERS).unwrap();
+            Consensus::<BANDWIDTH>::new(ComputeLayout::HubSpoke, PARALLEL_PRODUCERS, PARALLEL_PRODUCERS).unwrap();
         let mut spokes = Vec::new();
         for _ in 0..PARALLEL_PRODUCERS {
             spokes.push(consensus.register_producer(None).unwrap().unwrap());

--- a/src/mt/consensus.rs
+++ b/src/mt/consensus.rs
@@ -317,7 +317,7 @@ impl<const BANDWIDTH: usize> BlockProcessor<BANDWIDTH> {
         if self.mode != ComputeLayout::HubSpoke {
             return Err(AikaError::ComputeLayoutExpectationMismatch(self.mode));
         }
-        self.safe_point_centralized.as_mut().unwrap().push(gvt);
+        self.safe_point_centralized.as_mut().unwrap().push(gvt)?;
         Ok(())
     }
 }
@@ -604,7 +604,7 @@ mod unit_tests {
     }
 
     fn submit_block(spoke: &mut BlockSpoke<BANDWIDTH>, block: Block<BANDWIDTH>) {
-        spoke.submitter.write(block).unwrap();
+        spoke.submitter.push(block).unwrap();
     }
 
     #[test]
@@ -906,7 +906,7 @@ mod unit_tests {
                     }
 
                     // Submit block via the lock-free SPSC channel.
-                    spoke.submitter.write(block).unwrap();
+                    spoke.submitter.push(block).unwrap();
                     thread::sleep(Duration::from_micros(5));
                 }
             });

--- a/src/mt/engines/hlocal/bus.rs
+++ b/src/mt/engines/hlocal/bus.rs
@@ -9,21 +9,21 @@ use std::{
 };
 
 use bytemuck::{Pod, Zeroable};
-use mesocarp::comms::buses::ThreadedMessenger;
+use mesocarp::comms::mt::ThreadedMessenger;
 use mesocarp::MesoError;
 
 use crate::{objects::Transfer, AikaError};
 
-pub struct MessageBus<const MSG_BW: usize, MessageType: Pod + Zeroable + Clone> {
-    pub(crate) messenger: ThreadedMessenger<MSG_BW, Transfer<MessageType>>,
+pub struct MessageBus<MessageType: Pod + Zeroable + Clone> {
+    pub(crate) messenger: ThreadedMessenger<Transfer<MessageType>>,
     pub(crate) terminal_flag: Arc<AtomicBool>,
     pub(crate) log: Option<File>,
     pub(crate) start: Instant,
 }
 
-impl<const MSG_BW: usize, MessageType: Pod + Zeroable + Clone> MessageBus<MSG_BW, MessageType> {
+impl<MessageType: Pod + Zeroable + Clone> MessageBus<MessageType> {
     pub(crate) fn from_substrate(
-        messenger: ThreadedMessenger<MSG_BW, Transfer<MessageType>>,
+        messenger: ThreadedMessenger<Transfer<MessageType>>,
         log: Option<File>,
         start: Instant,
         terminal_flag: Arc<AtomicBool>,

--- a/src/mt/engines/hlocal/cluster.rs
+++ b/src/mt/engines/hlocal/cluster.rs
@@ -8,7 +8,7 @@ use std::{
 
 use bytemuck::{Pod, Zeroable};
 use mesocarp::{
-    comms::buses::{Message, ThreadedMessengerUser},
+    comms::mt::{Message, ThreadedMessengerUser},
     scheduling::Scheduleable,
 };
 
@@ -29,7 +29,6 @@ use crate::{
 /// triggered in inter-cluster messaging.
 pub struct Planet<
     const BLOCK_BW: usize,
-    const MSG_BW: usize,
     const CLOCK_BW: usize,
     const CLOCK_SCALES: usize,
     MessageType: Pod + Zeroable + Clone,
@@ -42,7 +41,7 @@ pub struct Planet<
     local_messages: LocalScheduler<CLOCK_BW, CLOCK_SCALES, Msg<MessageType>>,
     early_arrivals: Vec<Msg<MessageType>>,
     early_anti_arrivals: Vec<AntiMsg>,
-    pub(crate) message_user: ThreadedMessengerUser<MSG_BW, Transfer<MessageType>>,
+    pub(crate) message_user: ThreadedMessengerUser<Transfer<MessageType>>,
     pub(crate) blocks: BlockSpoke<BLOCK_BW>,
     /// Current time information of the simulation. these should always be the same across simulation clusters in the same `Substrate`.
     pub time: HTime,
@@ -57,36 +56,33 @@ pub struct Planet<
 
 unsafe impl<
         const BLOCK_BW: usize,
-        const MSG_BW: usize,
         const CLOCK_BW: usize,
         const CLOCK_SCALES: usize,
         MessageType: Pod + Zeroable + Clone,
-    > Send for Planet<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, MessageType>
+    > Send for Planet<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, MessageType>
 {
 }
 unsafe impl<
         const BLOCK_BW: usize,
-        const MSG_BW: usize,
         const CLOCK_BW: usize,
         const CLOCK_SCALES: usize,
         MessageType: Pod + Zeroable + Clone,
-    > Sync for Planet<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, MessageType>
+    > Sync for Planet<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, MessageType>
 {
 }
 
 impl<
         const BLOCK_BW: usize,
-        const MSG_BW: usize,
         const CLOCK_BW: usize,
         const CLOCK_SCALES: usize,
         MessageType: Pod + Zeroable + Clone,
-    > Planet<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, MessageType>
+    > Planet<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, MessageType>
 {
     pub(crate) fn from_galaxy_registration(
         env: impl Environment + 'static,
         time: HTime,
         blocks: BlockSpoke<BLOCK_BW>,
-        message_user: ThreadedMessengerUser<MSG_BW, Transfer<MessageType>>,
+        message_user: ThreadedMessengerUser<Transfer<MessageType>>,
         id: usize,
         start: Instant,
     ) -> Result<Self, AikaError> {
@@ -268,7 +264,7 @@ impl<
         }
         for msg in maybe.unwrap() {
             let to = msg.to();
-            if to != Some(usize::MAX) && to != Some(self.context.cluster_id) {
+            if to != usize::MAX && to != self.context.cluster_id {
                 if let Some(file) = &mut self.log {
                     writeln!(
                         file,
@@ -282,7 +278,7 @@ impl<
                 return Err(AikaError::MismatchedDeliveryAddress(
                     msg.from(),
                     self.context.cluster_id,
-                    to.unwrap(),
+                    to,
                 ));
             }
             let time = msg.time();
@@ -381,7 +377,7 @@ impl<
             // submit the current block than initialize the new one.
             self.blocks
                 .submitter
-                .write(std::mem::take(&mut self.blocks.block))?;
+                .push(std::mem::take(&mut self.blocks.block));
             self.blocks.block.block_nmb = new_id.1;
             self.blocks.block.producer_id = new_id.0;
             self.blocks.block.start = self.context.time;
@@ -472,7 +468,7 @@ impl<
         if !self.blocks.block.catchup_block || (self.now() < self.blocks.block.start) {
             for msg in sends {
                 let mut local = false;
-                if Some(self.context.cluster_id) == msg.to() {
+                if self.context.cluster_id == msg.to() {
                     match msg {
                         Transfer::Msg(msg) => self.commit_mail(msg),
                         Transfer::AntiMsg(anti_msg) => self.annihilate(anti_msg),
@@ -502,7 +498,7 @@ impl<
                     continue;
                 }
                 if !local {
-                    if msg.to() == Some(usize::MAX) {
+                    if msg.to() == usize::MAX {
                         // number of worlds add to sends
                     }
                     self.blocks.block.sends += 1;
@@ -631,7 +627,7 @@ impl<
             return Err(AikaError::MustSetBlockDuration);
         }
         loop {
-            if let Some(gvt) = self.blocks.subscriber.try_recv() {
+            if let Some(gvt) = self.blocks.subscriber.pop() {
                 if gvt < self.time.gvt {
                     return Err(AikaError::GVTisDecreasing);
                 }
@@ -687,7 +683,7 @@ impl<
             return Err(AikaError::MustSetBlockDuration);
         }
         loop {
-            if let Some(gvt) = self.blocks.subscriber.try_recv() {
+            if let Some(gvt) = self.blocks.subscriber.pop() {
                 writeln!(
                     self.log.as_mut().unwrap(),
                     "[{}] new GVT found: {gvt}",
@@ -815,7 +811,7 @@ mod planet_tests {
     }
 
     fn create_test_planet() -> Planet<8, 16, 32, 2, TestMsg> {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(1, 64).unwrap();
+        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(1, 64, 16).unwrap();
         galaxy.set_time_scale(1000);
         galaxy.with_block_duration(10);
         galaxy.spawn_cluster(Stateless).unwrap()
@@ -921,7 +917,7 @@ mod planet_tests {
 
     #[test]
     fn test_planet_checkpoint_handling() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(1, 64).unwrap();
+        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(1, 64, 16).unwrap();
         galaxy.set_time_scale(100);
         galaxy.with_block_duration(10);
         galaxy.checkpoints(2);

--- a/src/mt/engines/hlocal/cluster.rs
+++ b/src/mt/engines/hlocal/cluster.rs
@@ -377,7 +377,7 @@ impl<
             // submit the current block than initialize the new one.
             self.blocks
                 .submitter
-                .push(std::mem::take(&mut self.blocks.block));
+                .push(std::mem::take(&mut self.blocks.block)).map_err(|_| AikaError::MesoError(mesocarp::MesoError::BuffersFull))?;
             self.blocks.block.block_nmb = new_id.1;
             self.blocks.block.producer_id = new_id.0;
             self.blocks.block.start = self.context.time;
@@ -810,8 +810,8 @@ mod planet_tests {
         }
     }
 
-    fn create_test_planet() -> Planet<8, 16, 32, 2, TestMsg> {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(1, 64, 16).unwrap();
+    fn create_test_planet() -> Planet<8, 32, 2, TestMsg> {
+        let mut galaxy: Substrate<8, TestMsg> = Substrate::new(1, 64, 16).unwrap();
         galaxy.set_time_scale(1000);
         galaxy.with_block_duration(10);
         galaxy.spawn_cluster(Stateless).unwrap()
@@ -917,7 +917,7 @@ mod planet_tests {
 
     #[test]
     fn test_planet_checkpoint_handling() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(1, 64, 16).unwrap();
+        let mut galaxy: Substrate<8, TestMsg> = Substrate::new(1, 64, 16).unwrap();
         galaxy.set_time_scale(100);
         galaxy.with_block_duration(10);
         galaxy.checkpoints(2);

--- a/src/mt/engines/hlocal/cluster.rs
+++ b/src/mt/engines/hlocal/cluster.rs
@@ -23,7 +23,6 @@ use crate::{
     AikaError,
 };
 
-#[derive(Debug)]
 /// A `Planet` is a local simulation cluster within a `Substrate` system, owns a partition of global simulation state.
 /// It operates conservative with respect to its local actors, but allows rollbacks from causality violations
 /// triggered in inter-cluster messaging.

--- a/src/mt/engines/hlocal/gvt.rs
+++ b/src/mt/engines/hlocal/gvt.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use bytemuck::{Pod, Zeroable};
-use mesocarp::comms::buses::ThreadedMessenger;
+use mesocarp::comms::mt::ThreadedMessenger;
 
 use crate::{
     env::Environment,
@@ -28,12 +28,11 @@ use crate::{
 /// A `Substrate` is an inter-cluster message bus and GVT updater, intended to own its own thread.
 pub struct Substrate<
     const BLOCK_BW: usize,
-    const MSG_BW: usize,
     MessageType: Pod + Zeroable + Clone,
 > {
     /// The temporal consensus routine for an updted GVT computation.
     pub consensus: Consensus<BLOCK_BW>,
-    pub(crate) messenger: ThreadedMessenger<MSG_BW, Transfer<MessageType>>,
+    pub(crate) messenger: ThreadedMessenger<Transfer<MessageType>>,
     /// Current time information.
     pub time: HTime,
     /// Maximum duration of a block. Also the expected length of a block unless the simulation terminates early.
@@ -48,20 +47,20 @@ pub struct Substrate<
     start: Instant,
 }
 
-impl<const BLOCK_BW: usize, const MSG_BW: usize, MessageType: Pod + Zeroable + Clone>
-    Substrate<BLOCK_BW, MSG_BW, MessageType>
+impl<const BLOCK_BW: usize, MessageType: Pod + Zeroable + Clone>
+    Substrate<BLOCK_BW, MessageType>
 {
     /// Create a new `Substrate` with `planet_count: usize` maximum number of clusters, and `block_batch_size` arena allocation sizing for block logging.
-    pub fn new(planet_count: usize, block_batch_size: usize) -> Result<Self, AikaError> {
+    pub fn new(planet_count: usize, block_batch_size: usize, message_bandwidth: usize) -> Result<Self, AikaError> {
         let start = Instant::now();
         let mut planet_ids = Vec::new();
         for i in 0..planet_count {
             planet_ids.push(i);
         }
-        let messenger = ThreadedMessenger::new(planet_count)?;
+        let messenger = ThreadedMessenger::new(planet_count, message_bandwidth)?;
 
         Ok(Self {
-            consensus: Consensus::new(ComputeLayout::HubSpoke, block_batch_size)?,
+            consensus: Consensus::new(ComputeLayout::HubSpoke, block_batch_size, planet_count)?,
             messenger,
             time: HTime {
                 gvt: 0,
@@ -95,7 +94,7 @@ impl<const BLOCK_BW: usize, const MSG_BW: usize, MessageType: Pod + Zeroable + C
     pub fn spawn_cluster<const CLOCK_BW: usize, const CLOCK_SCALES: usize>(
         &mut self,
         env: impl Environment + 'static,
-    ) -> Result<Planet<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, MessageType>, AikaError> {
+    ) -> Result<Planet<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, MessageType>, AikaError> {
         if self.registered == self.planet_count {
             return Err(AikaError::MaximumClustersAllowed);
         }
@@ -115,7 +114,7 @@ impl<const BLOCK_BW: usize, const MSG_BW: usize, MessageType: Pod + Zeroable + C
 
     pub fn split_substrate(
         self,
-    ) -> Result<(GVT<BLOCK_BW>, MessageBus<MSG_BW, MessageType>), AikaError> {
+    ) -> Result<(GVT<BLOCK_BW>, MessageBus<MessageType>), AikaError> {
         if self.registered != self.planet_count {
             return Err(AikaError::NotAllClustersRegistered);
         }
@@ -142,7 +141,7 @@ impl<const BLOCK_BW: usize, const MSG_BW: usize, MessageType: Pod + Zeroable + C
         Ok((gvt, bus))
     }
 
-    pub fn rejoin_substrate(gvt: GVT<BLOCK_BW>, bus: MessageBus<MSG_BW, MessageType>) -> Self {
+    pub fn rejoin_substrate(gvt: GVT<BLOCK_BW>, bus: MessageBus<MessageType>) -> Self {
         let count = bus.messenger.capacity;
         let mut log = None;
         if bus.log.is_some() {
@@ -163,12 +162,12 @@ impl<const BLOCK_BW: usize, const MSG_BW: usize, MessageType: Pod + Zeroable + C
     }
 }
 
-unsafe impl<const BLOCK_BW: usize, const MSG_BW: usize, MessageType: Pod + Zeroable + Clone> Send
-    for Substrate<BLOCK_BW, MSG_BW, MessageType>
+unsafe impl<const BLOCK_BW: usize, MessageType: Pod + Zeroable + Clone> Send
+    for Substrate<BLOCK_BW, MessageType>
 {
 }
-unsafe impl<const BLOCK_BW: usize, const MSG_BW: usize, MessageType: Pod + Zeroable + Clone> Sync
-    for Substrate<BLOCK_BW, MSG_BW, MessageType>
+unsafe impl<const BLOCK_BW: usize, MessageType: Pod + Zeroable + Clone> Sync
+    for Substrate<BLOCK_BW, MessageType>
 {
 }
 
@@ -366,7 +365,7 @@ mod unit_tests {
 
     #[test]
     fn test_galaxy_creation() {
-        let galaxy: Substrate<8, 16, TestMsg> = Substrate::new(4, 128).unwrap();
+        let galaxy: Substrate<8, 16, TestMsg> = Substrate::new(4, 128, 16).unwrap();
         assert_eq!(galaxy.planet_count, 4);
         assert_eq!(galaxy.registered, 0);
         assert_eq!(galaxy.time.terminal, u64::MAX);
@@ -376,7 +375,7 @@ mod unit_tests {
 
     #[test]
     fn test_galaxy_configuration() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64).unwrap();
+        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64, 16).unwrap();
 
         galaxy.set_time_scale(1000);
         assert_eq!(galaxy.time.terminal, 1000);
@@ -390,7 +389,7 @@ mod unit_tests {
 
     #[test]
     fn test_planet_spawning() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(3, 64).unwrap();
+        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(3, 64, 16).unwrap();
 
         let planet1 = galaxy.spawn_cluster::<32, 2>(Stateless).unwrap();
         assert_eq!(galaxy.registered, 1);
@@ -410,7 +409,7 @@ mod unit_tests {
 
     #[test]
     fn test_galaxy_terminal_time_requirement() {
-        let mut substrate: Substrate<8, 16, TestMsg> = Substrate::new(2, 64).unwrap();
+        let mut substrate: Substrate<8, 16, TestMsg> = Substrate::new(2, 64, 16).unwrap();
         substrate.spawn_cluster::<128, 1>(Stateless).unwrap();
         substrate.spawn_cluster::<128, 1>(Stateless).unwrap();
         let (galaxy, _) = substrate.split_substrate().unwrap();
@@ -420,7 +419,7 @@ mod unit_tests {
 
     #[test]
     fn test_message_delivery() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64).unwrap();
+        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64, 16).unwrap();
         galaxy.set_time_scale(100);
 
         let mut planet1 = galaxy.spawn_cluster::<32, 2>(Stateless).unwrap();
@@ -445,7 +444,7 @@ mod unit_tests {
 
     #[test]
     fn test_check_all_terminal() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64).unwrap();
+        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64, 16).unwrap();
         galaxy.set_time_scale(100);
         galaxy.with_block_duration(50);
 

--- a/src/mt/engines/hlocal/gvt.rs
+++ b/src/mt/engines/hlocal/gvt.rs
@@ -365,7 +365,7 @@ mod unit_tests {
 
     #[test]
     fn test_galaxy_creation() {
-        let galaxy: Substrate<8, 16, TestMsg> = Substrate::new(4, 128, 16).unwrap();
+        let galaxy: Substrate<8, TestMsg> = Substrate::new(4, 128, 16).unwrap();
         assert_eq!(galaxy.planet_count, 4);
         assert_eq!(galaxy.registered, 0);
         assert_eq!(galaxy.time.terminal, u64::MAX);
@@ -375,7 +375,7 @@ mod unit_tests {
 
     #[test]
     fn test_galaxy_configuration() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64, 16).unwrap();
+        let mut galaxy: Substrate<8, TestMsg> = Substrate::new(2, 64, 16).unwrap();
 
         galaxy.set_time_scale(1000);
         assert_eq!(galaxy.time.terminal, 1000);
@@ -389,7 +389,7 @@ mod unit_tests {
 
     #[test]
     fn test_planet_spawning() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(3, 64, 16).unwrap();
+        let mut galaxy: Substrate<8, TestMsg> = Substrate::new(3, 64, 16).unwrap();
 
         let planet1 = galaxy.spawn_cluster::<32, 2>(Stateless).unwrap();
         assert_eq!(galaxy.registered, 1);
@@ -409,7 +409,7 @@ mod unit_tests {
 
     #[test]
     fn test_galaxy_terminal_time_requirement() {
-        let mut substrate: Substrate<8, 16, TestMsg> = Substrate::new(2, 64, 16).unwrap();
+        let mut substrate: Substrate<8, TestMsg> = Substrate::new(2, 64, 16).unwrap();
         substrate.spawn_cluster::<128, 1>(Stateless).unwrap();
         substrate.spawn_cluster::<128, 1>(Stateless).unwrap();
         let (galaxy, _) = substrate.split_substrate().unwrap();
@@ -419,7 +419,7 @@ mod unit_tests {
 
     #[test]
     fn test_message_delivery() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64, 16).unwrap();
+        let mut galaxy: Substrate<8, TestMsg> = Substrate::new(2, 64, 16).unwrap();
         galaxy.set_time_scale(100);
 
         let mut planet1 = galaxy.spawn_cluster::<32, 2>(Stateless).unwrap();
@@ -444,7 +444,7 @@ mod unit_tests {
 
     #[test]
     fn test_check_all_terminal() {
-        let mut galaxy: Substrate<8, 16, TestMsg> = Substrate::new(2, 64, 16).unwrap();
+        let mut galaxy: Substrate<8, TestMsg> = Substrate::new(2, 64, 16).unwrap();
         galaxy.set_time_scale(100);
         galaxy.with_block_duration(50);
 
@@ -462,12 +462,12 @@ mod unit_tests {
         planet1
             .blocks
             .submitter
-            .write(planet1.blocks.block)
+            .push(planet1.blocks.block)
             .unwrap();
         planet2
             .blocks
             .submitter
-            .write(planet2.blocks.block)
+            .push(planet2.blocks.block)
             .unwrap();
 
         galaxy.consensus.poll_n_slot().unwrap();

--- a/src/mt/engines/hlocal/mod.rs
+++ b/src/mt/engines/hlocal/mod.rs
@@ -551,7 +551,8 @@ mod unit_tests {
         assert!(substrate_result.is_ok());
         assert!(
             planet_result.is_ok(),
-            "Planet run loop failed: {planet_result:?}"
+            "Planet run loop failed: {:?}",
+            planet_result.err().unwrap()
         );
         assert!(bus_result.is_ok())
     }

--- a/src/mt/engines/hlocal/mod.rs
+++ b/src/mt/engines/hlocal/mod.rs
@@ -37,6 +37,7 @@ mod gvt;
 /// A `Config` packages all of the configuration information for the simulation's GVT/consensus algorithm.
 pub struct Config {
     pub clusters: usize,
+    pub message_bandwidth: usize,
     pub batch_size: usize,
     pub block_duration: u64,
     pub terminal: u64,
@@ -46,6 +47,7 @@ pub struct Config {
 impl Config {
     pub fn new(
         clusters: usize,
+        message_bandwidth: usize,
         batch_size: usize,
         block_duration: u64,
         terminal: u64,
@@ -53,6 +55,7 @@ impl Config {
     ) -> Self {
         Self {
             clusters,
+            message_bandwidth,
             batch_size,
             block_duration,
             terminal,
@@ -64,23 +67,21 @@ impl Config {
 /// A `Stager` is the main entry point to simulations. It provides a clean interface for staging and running `hlocal` simulations.
 pub struct Stager<
     const BLOCK_BW: usize,
-    const MSG_BW: usize,
     const CLOCK_BW: usize,
     const CLOCK_SCALES: usize,
     MessageType: Pod + Zeroable + Clone,
 > {
-    pub substrate: Option<Substrate<BLOCK_BW, MSG_BW, MessageType>>,
-    pub clusters: Vec<Planet<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, MessageType>>,
+    pub substrate: Option<Substrate<BLOCK_BW, MessageType>>,
+    pub clusters: Vec<Planet<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, MessageType>>,
     configured: bool,
 }
 
 impl<
         const BLOCK_BW: usize,
-        const MSG_BW: usize,
         const CLOCK_BW: usize,
         const CLOCK_SCALES: usize,
         MessageType: Pod + Zeroable + Clone,
-    > Stager<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, MessageType>
+    > Stager<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, MessageType>
 {
     pub fn new() -> Result<Self, AikaError> {
         Ok(Self {
@@ -91,7 +92,7 @@ impl<
     }
 
     pub fn config(&mut self, config: Config) -> Result<(), AikaError> {
-        let mut substrate = Substrate::new(config.clusters, config.batch_size)?;
+        let mut substrate = Substrate::new(config.clusters, config.batch_size, config.message_bandwidth)?;
         substrate.set_time_scale(config.terminal);
         substrate.with_block_duration(config.block_duration);
         substrate.checkpoints(config.checkpoint_frequency);
@@ -198,7 +199,7 @@ impl<
                             barrier_clone.wait();
                             let planet = planet.run()?;
                             Ok::<
-                                Planet<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, MessageType>,
+                                Planet<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, MessageType>,
                                 AikaError,
                             >(planet)
                         })
@@ -224,7 +225,7 @@ impl<
                                 barrier_clone.wait();
                                 let planet = planet.run_debug()?;
                                 Ok::<
-                                    Planet<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, MessageType>,
+                                    Planet<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, MessageType>,
                                     AikaError,
                                 >(planet)
                             })
@@ -256,7 +257,7 @@ impl<
             .spawn(move || {
                 barrier.wait();
                 let bus = bus.master()?;
-                Ok::<MessageBus<MSG_BW, MessageType>, AikaError>(bus)
+                Ok::<MessageBus<MessageType>, AikaError>(bus)
             })
             .map_err(|_| AikaError::ThreadPanic)?;
 
@@ -504,15 +505,15 @@ mod unit_tests {
         block_dur: u64,
     ) -> Result<
         (
-            Substrate<BLOCK_BANDWIDTH, MSG_BANDWIDTH, MessageType>,
-            Planet<BLOCK_BANDWIDTH, MSG_BANDWIDTH, CLOCK_BW, CLOCK_SCALES, MessageType>,
+            Substrate<BLOCK_BANDWIDTH, MessageType>,
+            Planet<BLOCK_BANDWIDTH, CLOCK_BW, CLOCK_SCALES, MessageType>,
         ),
         AikaError,
     >
     where
         TestAgent: ConnectedActor<MessageType>,
     {
-        let mut substrate = Substrate::<BLOCK_BANDWIDTH, MSG_BANDWIDTH, MessageType>::new(1, 12)?;
+        let mut substrate = Substrate::<BLOCK_BANDWIDTH, MessageType>::new(1, 12, MSG_BANDWIDTH)?;
         substrate.set_time_scale(terminal);
         substrate.with_block_duration(block_dur);
         let mut planet = substrate.spawn_cluster::<CLOCK_BW, CLOCK_SCALES>(SimpleUnified {
@@ -574,10 +575,11 @@ mod unit_tests {
     fn test_multiplanet_setup() {
         const CLUSTERS: usize = 6;
         let mut stager =
-            Stager::<BLOCK_BANDWIDTH, MSG_BANDWIDTH, 64, 2, TestMessage>::new().unwrap();
+            Stager::<BLOCK_BANDWIDTH, 64, 2, TestMessage>::new().unwrap();
 
         let config = Config {
             clusters: CLUSTERS,
+            message_bandwidth: MSG_BANDWIDTH,
             batch_size: 12,
             block_duration: 1,
             terminal: 20,
@@ -608,7 +610,7 @@ mod unit_tests {
 
     #[test]
     fn test_rollback_accounting() {
-        let mut substrate: Substrate<8, 8, TestMessage> = Substrate::new(1, 1).unwrap();
+        let mut substrate: Substrate<8, TestMessage> = Substrate::new(1, 1, 8).unwrap();
         let mut planet = substrate
             .spawn_cluster::<16, 2>(SimpleUnified {
                 inner: Journal::init(1024),
@@ -767,10 +769,10 @@ mod messaging_tests {
 
     #[test]
     fn test_local_messaging() {
-        let mut stager: Stager<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, Message> =
+        let mut stager: Stager<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, Message> =
             Stager::new().unwrap();
 
-        let config = Config::new(1, 128, 20, 2048, 10000000);
+        let config = Config::new(1, MSG_BW, 128, 20, 2048, 10000000);
         stager.config(config).unwrap();
 
         stager.create_cluster(Stateless).unwrap();
@@ -789,10 +791,10 @@ mod messaging_tests {
 
     #[test]
     fn test_local_messaging_heavy() {
-        let mut stager: Stager<BLOCK_BW, MSG_BW, CLOCK_BW, CLOCK_SCALES, Message> =
+        let mut stager: Stager<BLOCK_BW, CLOCK_BW, CLOCK_SCALES, Message> =
             Stager::new().unwrap();
 
-        let config = Config::new(1, 128, 20, 204, 10000000);
+        let config = Config::new(1, MSG_BW, 128, 20, 204, 10000000);
         stager.config(config).unwrap();
 
         stager.create_cluster(Stateless).unwrap();
@@ -808,9 +810,9 @@ mod messaging_tests {
 
     #[test]
     fn test_intercluster_messaging() {
-        let mut stager: Stager<216, 1024, CLOCK_BW, CLOCK_SCALES, Message> = Stager::new().unwrap();
+        let mut stager: Stager<216, CLOCK_BW, CLOCK_SCALES, Message> = Stager::new().unwrap();
 
-        let config = Config::new(2, 128, 128, 2048, 10);
+        let config = Config::new(2, 1024, 128, 128, 2048, 10);
         stager.config(config).unwrap();
 
         stager.create_cluster(Stateless).unwrap();

--- a/src/mt/engines/hlocal/mod.rs
+++ b/src/mt/engines/hlocal/mod.rs
@@ -305,37 +305,22 @@ impl<
 macro_rules! stager {
     // Just the message type - use all defaults
     ($msg_type:ty) => {
-        $crate::mt::engines::hlocal::Stager::<32, 128, 128, 2, $msg_type>::new()
+        $crate::mt::engines::hlocal::Stager::<32, 128, 2, $msg_type>::new()
     };
 
     // With BLOCK_BW only
     ($msg_type:ty, BLOCK_BW = $block_bw:expr) => {
-        $crate::mt::engines::hlocal::Stager::<$block_bw, 128, 128, 2, $msg_type>::new()
-    };
-
-    // With MSG_BW only
-    ($msg_type:ty, MSG_BW = $msg_bw:expr) => {
-        $crate::mt::engines::hlocal::Stager::<32, $msg_bw, 128, 2, $msg_type>::new()
+        $crate::mt::engines::hlocal::Stager::<$block_bw, 128, 2, $msg_type>::new()
     };
 
     // With CLOCK_BW only
     ($msg_type:ty, CLOCK_BW = $clock_bw:expr) => {
-        $crate::mt::engines::hlocal::Stager::<32, 128, $clock_bw, 2, $msg_type>::new()
+        $crate::mt::engines::hlocal::Stager::<32, $clock_bw, 2, $msg_type>::new()
     };
 
     // With CLOCK_SCALES only
     ($msg_type:ty, CLOCK_SCALES = $clock_scales:expr) => {
-        $crate::mt::engines::hlocal::Stager::<32, 128, 128, $clock_scales, $msg_type>::new()
-    };
-
-    // With BLOCK_BW and MSG_BW
-    ($msg_type:ty, BLOCK_BW = $block_bw:expr, MSG_BW = $msg_bw:expr) => {
-        $crate::mt::engines::hlocal::Stager::<$block_bw, $msg_bw, 128, 2, $msg_type>::new()
-    };
-
-    // With MSG_BW and BLOCK_BW
-    ($msg_type:ty, MSG_BW = $msg_bw:expr, BLOCK_BW = $block_bw:expr) => {
-        $crate::mt::engines::hlocal::Stager::<$block_bw, $msg_bw, 128, 2, $msg_type>::new()
+        $crate::mt::engines::hlocal::Stager::<32, 128, $clock_scales, $msg_type>::new()
     };
 
     // With BLOCK_BW and CLOCK_BW
@@ -349,43 +334,43 @@ macro_rules! stager {
     };
 
     // With MSG_BW and CLOCK_BW
-    ($msg_type:ty, MSG_BW = $msg_bw:expr, CLOCK_BW = $clock_bw:expr) => {
-        $crate::mt::engines::hlocal::Stager::<32, $msg_bw, $clock_bw, 2, $msg_type>::new()
+    ($msg_type:ty, CLOCK_BW = $clock_bw:expr) => {
+        $crate::mt::engines::hlocal::Stager::<32, $clock_bw, 2, $msg_type>::new()
     };
 
     // With MSG_BW and CLOCK_SCALES
-    ($msg_type:ty, MSG_BW = $msg_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
-        $crate::mt::engines::hlocal::Stager::<32, $msg_bw, 128, $clock_scales, $msg_type>::new()
+    ($msg_type:ty, CLOCK_SCALES = $clock_scales:expr) => {
+        $crate::mt::engines::hlocal::Stager::<32, $clock_scales, $msg_type>::new()
     };
 
     // With CLOCK_BW and CLOCK_SCALES
     ($msg_type:ty, CLOCK_BW = $clock_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
-        $crate::mt::engines::hlocal::Stager::<32, 128, $clock_bw, $clock_scales, $msg_type>::new()
+        $crate::mt::engines::hlocal::Stager::<32, $clock_bw, $clock_scales, $msg_type>::new()
     };
 
     // With BLOCK_BW, MSG_BW, and CLOCK_BW
-    ($msg_type:ty, BLOCK_BW = $block_bw:expr, MSG_BW = $msg_bw:expr, CLOCK_BW = $clock_bw:expr) => {
-        $crate::mt::engines::hlocal::Stager::<$block_bw, $msg_bw, $clock_bw, 2, $msg_type>::new()
+    ($msg_type:ty, BLOCK_BW = $block_bw:expr, CLOCK_BW = $clock_bw:expr) => {
+        $crate::mt::engines::hlocal::Stager::<$block_bw, $clock_bw, 2, $msg_type>::new()
     };
 
     // With BLOCK_BW, MSG_BW, and CLOCK_SCALES
-    ($msg_type:ty, BLOCK_BW = $block_bw:expr, MSG_BW = $msg_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
-        $crate::mt::engines::hlocal::Stager::<$block_bw, $msg_bw, 128, $clock_scales, $msg_type>::new()
+    ($msg_type:ty, BLOCK_BW = $block_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
+        $crate::mt::engines::hlocal::Stager::<$block_bw, 128, $clock_scales, $msg_type>::new()
     };
 
     // With BLOCK_BW, CLOCK_BW, and CLOCK_SCALES
     ($msg_type:ty, BLOCK_BW = $block_bw:expr, CLOCK_BW = $clock_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
-        $crate::mt::engines::hlocal::Stager::<$block_bw, 128, $clock_bw, $clock_scales, $msg_type>::new()
+        $crate::mt::engines::hlocal::Stager::<$block_bw, $clock_bw, $clock_scales, $msg_type>::new()
     };
 
     // With MSG_BW, CLOCK_BW, and CLOCK_SCALES
-    ($msg_type:ty, MSG_BW = $msg_bw:expr, CLOCK_BW = $clock_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
-        $crate::mt::engines::hlocal::Stager::<32, $msg_bw, $clock_bw, $clock_scales, $msg_type>::new()
+    ($msg_type:ty, CLOCK_BW = $clock_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
+        $crate::mt::engines::hlocal::Stager::<32, $clock_bw, $clock_scales, $msg_type>::new()
     };
 
     // With all parameters
-    ($msg_type:ty, BLOCK_BW = $block_bw:expr, MSG_BW = $msg_bw:expr, CLOCK_BW = $clock_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
-        $crate::mt::engines::hlocal::Stager::<$block_bw, $msg_bw, $clock_bw, $clock_scales, $msg_type>::new()
+    ($msg_type:ty, BLOCK_BW = $block_bw:expr, CLOCK_BW = $clock_bw:expr, CLOCK_SCALES = $clock_scales:expr) => {
+        $crate::mt::engines::hlocal::Stager::<$block_bw, $clock_bw, $clock_scales, $msg_type>::new()
     };
 }
 
@@ -398,7 +383,7 @@ mod unit_tests {
     use crate::env::SimpleUnified;
     use crate::objects::{AntiMsg, Msg, SchedulingTask};
     use bytemuck::{Pod, Zeroable};
-    use mesocarp::logging::journal::Journal;
+    use mesocarp::logging::Journal;
     use mesocarp::scheduling::Scheduleable;
     use mesocarp::MesoError;
 
@@ -531,7 +516,7 @@ mod unit_tests {
         const CLOCK_SCALES: usize,
         MessageType: Pod + Zeroable + Clone,
     >(
-        cluster: &mut Planet<BLOCK_BANDWIDTH, MSG_BANDWIDTH, CLOCK_BW, CLOCK_SCALES, MessageType>,
+        cluster: &mut Planet<BLOCK_BANDWIDTH, CLOCK_BW, CLOCK_SCALES, MessageType>,
         time: u64,
     ) -> Result<(), AikaError> {
         for i in 0..AGENTS {
@@ -544,8 +529,8 @@ mod unit_tests {
     fn test_stager_macro() {
         stager!(TestMessage).unwrap();
         stager!(TestMessage, BLOCK_BW = 48).unwrap();
-        stager!(TestMessage, BLOCK_BW = 48, MSG_BW = 12).unwrap();
-        stager!(TestMessage, MSG_BW = 12, CLOCK_BW = 128).unwrap();
+        stager!(TestMessage, BLOCK_BW = 48).unwrap();
+        stager!(TestMessage, CLOCK_BW = 128).unwrap();
         stager!(TestMessage, CLOCK_BW = 128, CLOCK_SCALES = 1).unwrap();
     }
 
@@ -828,32 +813,32 @@ mod messaging_tests {
         stager.schedule_cluster(0, 1).unwrap();
         stager.schedule_cluster(1, 1).unwrap();
 
-        stager.run(RunMode::Debug).unwrap();
+        stager.run(RunMode::Fast).unwrap();
     }
 
-    // #[test]
-    // fn test_intercluster_messaging_heavy() {
-    //     let mut stager = stager!(Message, MSG_BW = { 16 * 1024 }, BLOCK_BW = 128).unwrap();
-    //     let config = Config::new(4, 32, 48, 2048, 10);
-    //     stager.config(config).unwrap();
+    #[test]
+    fn test_intercluster_messaging_heavy() {
+        let mut stager = stager!(Message, BLOCK_BW = 128).unwrap();
+        let config = Config::new(4, 16 * 1024, 32, 48, 2048, 10);
+        stager.config(config).unwrap();
 
-    //     stager.create_cluster(Stateless).unwrap();
-    //     stager.create_cluster(Stateless).unwrap();
-    //     stager.create_cluster(Stateless).unwrap();
-    //     stager.create_cluster(Stateless).unwrap();
+        stager.create_cluster(Stateless).unwrap();
+        stager.create_cluster(Stateless).unwrap();
+        stager.create_cluster(Stateless).unwrap();
+        stager.create_cluster(Stateless).unwrap();
 
-    //     for i in 0..4 {
-    //         for j in 0..10 {
-    //             stager
-    //                 .spawn_actor_on_cluster(
-    //                     i,
-    //                     MessagingActor::new((j + 1) % 10, (i + 1) % 4, 2, 2),
-    //                 )
-    //                 .unwrap();
-    //         }
-    //     }
+        for i in 0..4 {
+            for j in 0..10 {
+                stager
+                    .spawn_actor_on_cluster(
+                        i,
+                        MessagingActor::new((j + 1) % 10, (i + 1) % 4, 2, 2),
+                    )
+                    .unwrap();
+            }
+        }
 
-    //     stager.schedule_all(1).unwrap();
-    //     stager.run(RunMode::Debug).unwrap();
-    // }
+        stager.schedule_all(1).unwrap();
+        stager.run(RunMode::Fast).unwrap();
+    }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use bytemuck::{Pod, Zeroable};
-use mesocarp::comms::buses::Message;
-use mesocarp::scheduling::{htw::Clock, Scheduleable};
+use mesocarp::comms::mt::Message;
+use mesocarp::scheduling::{Clock, Scheduleable};
 
 use crate::AikaError;
 
@@ -150,10 +150,10 @@ impl<T: Pod + Zeroable + Clone> Message for Transfer<T> {
         }
     }
 
-    fn to(&self) -> Option<usize> {
+    fn to(&self) -> usize {
         match self {
-            Transfer::Msg(msg) => Some(msg.to.0),
-            Transfer::AntiMsg(anti_msg) => Some(anti_msg.to.0),
+            Transfer::Msg(msg) => msg.to.0,
+            Transfer::AntiMsg(anti_msg) => anti_msg.to.0,
         }
     }
 }

--- a/src/st/mod.rs
+++ b/src/st/mod.rs
@@ -2,7 +2,7 @@
 //! Provides a `LonePlanet` struct that manages actor execution, event scheduling, and local message
 //! delivery in a deterministic single-threaded environment with configurable time bounds.
 use bytemuck::{Pod, Zeroable};
-use mesocarp::comms::buses::Message;
+use mesocarp::comms::mt::Message;
 
 use crate::{
     actors::{Actor, ActorType, ConnectedActor, Context},
@@ -181,8 +181,8 @@ impl<const CLOCK_SLOTS: usize, const CLOCK_HEIGHT: usize, MessageType: Pod + Zer
 
             let sends = std::mem::take(&mut self.env.outbox);
             for msg in sends {
-                if msg.to() != Some(usize::MAX) {
-                    if Some(self.env.cluster_id) == msg.to() {
+                if msg.to() != usize::MAX {
+                    if self.env.cluster_id == msg.to() {
                         match msg {
                             Transfer::Msg(msg) => self.commit_mail(msg),
                             Transfer::AntiMsg(_) => return Err(AikaError::ThreadPanic),


### PR DESCRIPTION
in title. `mesocarp` v0.12.1 shifts to using crossbeam-queue for lock-free channels instead of attempting fragile pure atomics. This propagates that change to the multi-threaded runtime. Still failing on the contentious working however, so will need more testing before a merge